### PR TITLE
fix: missing `scripts` field in `package.json`

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -29,7 +29,13 @@ class Init {
     const packageInfo = JSON.parse(await this.readFile('package.json'))
 
     // update 'scripts'
+    if (!('scripts' in packageInfo)) {
+      packageInfo.scripts = {}
+    }
     const { scripts } = packageInfo
+    if (!('test' in scripts)) {
+      scripts.test = 'test'
+    }
     Object.assign(scripts, {
       'test:watch': `${scripts.test} --watch`,
       'test:coverage': 'echo "unsupported." && exit 1',

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -31,7 +31,7 @@ suite('init', () => {
     await fs.remove(workDir)
   })
 
-  test('write package.json', async () => {
+  test('update package.json', async () => {
     await exec('init')
     const pkg = await fs.readJson(packageJson)
 
@@ -64,6 +64,16 @@ suite('init', () => {
         postchangelog: 'prepend CHANGELOG.md "<!-- markdownlint-disable -->\n"',
       },
     })
+  })
+
+  test('update package.json without fields', async () => {
+    await fs.writeJson(packageJson, {})
+    await exec('init')
+    const pkg = await fs.readJson(packageJson)
+    assert('scripts' in pkg)
+    assert('test' in pkg.scripts)
+    assert('lint-staged' in pkg)
+    assert('standard-version' in pkg)
   })
 
   test('copy .editorconfig', async () => {


### PR DESCRIPTION
If `scripts` or `scripts.test` field did not exist, error was raised.