### PR TITLE
fix(commitlint): avoid Angular's new commit convention

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['@commitlint/config-angular'],
+  extends: ['@commitlint/config-conventional'],
 
   rules: {
     'scope-enum': [2, 'always', [

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@commitlint/cli": "^5.0.1",
-    "@commitlint/config-angular": "^5.0.1",
+    "@commitlint/cli": "^5.2.0",
+    "@commitlint/config-conventional": "^5.1.3",
     "eslint": "^4.12.1",
     "eslint-config-ybiquitous": "^3.0.1",
     "fs-extra": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,30 +2,24 @@
 # yarn lockfile v1
 
 
-"@commitlint/cli@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-5.0.1.tgz#656f005ef24c1d5894482e549ad7c9ef3377ea7c"
+"@commitlint/cli@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-5.2.0.tgz#ec28f6488371ffade98f7fc9a3b3fd8ba25da7bd"
   dependencies:
-    "@commitlint/core" "^5.0.1"
-    babel-polyfill "^6.23.0"
-    chalk "^2.0.1"
-    get-stdin "^5.0.1"
-    lodash "^4.17.4"
-    meow "^3.7.0"
+    "@commitlint/core" "^5.2.0"
+    babel-polyfill "6.26.0"
+    chalk "2.3.0"
+    get-stdin "5.0.1"
+    lodash "4.17.4"
+    meow "3.7.0"
 
-"@commitlint/config-angular-type-enum@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-angular-type-enum/-/config-angular-type-enum-5.0.1.tgz#52a112c3e7c6df2b451531bf20ae01140af7273c"
+"@commitlint/config-conventional@^5.1.3":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-conventional/-/config-conventional-5.1.3.tgz#460a92feaa2911bc49731d5922052fed4be4e07f"
 
-"@commitlint/config-angular@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-angular/-/config-angular-5.0.1.tgz#56a791ca8791addefa12f51a7c077560c991307b"
-  dependencies:
-    "@commitlint/config-angular-type-enum" "^5.0.1"
-
-"@commitlint/core@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@commitlint/core/-/core-5.0.1.tgz#4d2d6d40af44f60ff38e4b2f45269a5087baebc1"
+"@commitlint/core@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@commitlint/core/-/core-5.2.0.tgz#ebdd3f93a54ca281c36fae238aed72fe185a1c20"
   dependencies:
     "@marionebl/conventional-commits-parser" "^3.0.0"
     "@marionebl/git-raw-commits" "^1.2.0"
@@ -36,9 +30,8 @@
     cosmiconfig "^3.0.1"
     find-up "^2.1.0"
     lodash "^4.17.4"
-    path-exists "^3.0.0"
     require-uncached "^1.0.3"
-    resolve-from "^3.0.0"
+    resolve-from "^4.0.0"
     resolve-global "^0.1.0"
     semver "^5.3.0"
 
@@ -715,7 +708,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.23.0, babel-polyfill@^6.26.0:
+babel-polyfill@6.26.0, babel-polyfill@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   dependencies:
@@ -926,6 +919,14 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chalk@2.3.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -935,14 +936,6 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
-
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 chardet@^0.4.0:
   version "0.4.0"
@@ -1928,13 +1921,13 @@ get-pkg-repo@^1.0.0:
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
 
+get-stdin@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
-
-get-stdin@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -2730,7 +2723,7 @@ lodash.values@~4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.2.0.tgz#932625f7d2c954b63db895255548f3b49f120e9a"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2837,7 +2830,7 @@ memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
 
-meow@^3.3.0, meow@^3.7.0:
+meow@3.7.0, meow@^3.3.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -3595,9 +3588,9 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve-from@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
 resolve-global@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
Angular's new commit convention removed `chore` type.
But `standard-version` is supporting `chore` type yet.
So replace `@commitlint/config-angular` with `@commitlint/config-conventional`.

For details, see below:

https://github.com/marionebl/commitlint/tree/master/@commitlint/config-conventional