### PR TITLE
fix(markdownlint): stop writing CHANGELOG.md before release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable -->
 # Change Log
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "lint-staged": "^6.0.0",
     "markdownlint-cli": "^0.7.0",
     "npm-run-all": "^4.1.2",
-    "prepend-file-cli": "^1.0.6",
     "prettier": "^1.10.2",
     "semver": "^5.5.0",
     "standard-version": "^4.3.0",
@@ -59,7 +58,7 @@
     "test:coverage": "nyc report --reporter=text-lcov > coverage.lcov",
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
-    "lint:md": "markdownlint --ignore node_modules \"**/*.md\"",
+    "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
     "lint": "npm-run-all --print-name --print-label --parallel lint:*",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "precommit": "lint-staged",
@@ -74,10 +73,7 @@
     "*.md": "markdownlint"
   },
   "standard-version": {
-    "message": "chore(release): new version %s",
-    "scripts": {
-      "postchangelog": "prepend CHANGELOG.md \"<!-- markdownlint-disable -->\n\""
-    }
+    "message": "chore(release): new version %s"
   },
   "nyc": {
     "exclude": [

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -43,7 +43,8 @@ suite('init', () => {
       commitmsg: 'commitlint -e $GIT_PARAMS',
       'lint:js': 'eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .',
       'lint:js:fix': 'npm run lint:js -- --fix',
-      'lint:md': 'markdownlint --ignore node_modules "**/*.md"',
+      'lint:md':
+        'markdownlint --ignore node_modules --ignore CHANGELOG.md "**/*.md"',
       lint: 'npm-run-all --print-name --print-label --parallel lint:*',
       precommit: 'lint-staged',
       release: 'standard-version',
@@ -61,9 +62,6 @@ suite('init', () => {
 
     assert.deepStrictEqual(pkg['standard-version'], {
       message: 'chore(release): new version %s',
-      scripts: {
-        postchangelog: 'prepend CHANGELOG.md "<!-- markdownlint-disable -->\n"',
-      },
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3401,7 +3401,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -3569,19 +3569,6 @@ pluralize@^7.0.0:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
-
-prepend-file-cli@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/prepend-file-cli/-/prepend-file-cli-1.0.6.tgz#ff7e116c9314db85c22c43a2a07f3f9387a9a74f"
-  dependencies:
-    minimist "^1.2.0"
-    prepend-file "1.3.1"
-
-prepend-file@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/prepend-file/-/prepend-file-1.3.1.tgz#83b16e0b4ac1901fce88dbd945a22f4cc81df579"
-  dependencies:
-    tmp "0.0.31"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -4280,12 +4267,6 @@ through2@^2.0.0, through2@^2.0.2:
 through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-tmp@0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
via `--ignore` option of `markdownlint` command.