### PR TITLE
ci: support Node 10, drop Node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 9
+  - 10
   - 8
   - 6
 


### PR DESCRIPTION
Node 9 is not LTS.
See <https://github.com/nodejs/Release>.