### PR TITLE
feat(init): remove `standard-version` custom settings

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -55,7 +55,7 @@ class Init {
       })
 
     // update other keys
-    const keys = ['lint-staged', 'standard-version']
+    const keys = ['lint-staged']
     keys.forEach(key => {
       if (!(key in packageInfo)) {
         packageInfo[key] = {}

--- a/package.json
+++ b/package.json
@@ -65,9 +65,6 @@
     ],
     "*.md": "markdownlint --ignore CHANGELOG.md"
   },
-  "standard-version": {
-    "message": "chore(release): new version %s"
-  },
   "nyc": {
     "exclude": [
       "lib",

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -18,8 +18,5 @@
       "git add"
     ],
     "*.md": "markdownlint --ignore CHANGELOG.md"
-  },
-  "standard-version": {
-    "message": "chore(release): new version %s"
   }
 }

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -19,8 +19,5 @@
       "git add"
     ],
     "*.md": "markdownlint --ignore CHANGELOG.md"
-  },
-  "standard-version": {
-    "message": "chore(release): new version %s"
   }
 }


### PR DESCRIPTION
Because a commit message such as `chore(release): 3.0.3` is valid now.