### PR TITLE
feat(prettier): add Markdown support

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -19,6 +19,7 @@ module.exports = {
         'api',
         'markdownlint',
         'travis',
+        'prettier',
       ],
     ],
   },

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/lib/init.js
+++ b/lib/init.js
@@ -77,6 +77,7 @@ module.exports = async function init() {
   const cmd = new Init(process.cwd())
   await cmd.updatePackageFile()
   await cmd.writePackageFile('.editorconfig')
+  await cmd.writePackageFile('.prettierignore')
   await cmd.writeTemplateFile('.eslintrc.js')
   await cmd.writeTemplateFile('.commitlintrc.js')
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "bin",
     "lib",
     "templates",
-    ".editorconfig"
+    ".editorconfig",
+    ".prettierignore"
   ],
   "engines": {
     "node": ">=8"
@@ -54,6 +55,7 @@
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
+    "lint:md:fix": "prettier --write \"**/*.md\"",
     "lint": "npm-run-all --print-name --print-label --parallel lint:*",
     "commitmsg": "commitlint -E GIT_PARAMS",
     "precommit": "lint-staged",
@@ -66,7 +68,11 @@
         "eslint --fix --no-ignore",
         "git add"
       ],
-      "*.md": "markdownlint"
+      "*.md": [
+        "prettier --write",
+        "markdownlint",
+        "git add"
+      ]
     },
     "ignore": [
       "CHANGELOG.md"

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -6,6 +6,7 @@
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
+    "lint:md:fix": "prettier --write \"**/*.md\"",
     "lint": "npm-run-all --print-name --print-label --parallel lint:*",
     "commitmsg": "commitlint -E GIT_PARAMS",
     "precommit": "lint-staged",
@@ -18,7 +19,11 @@
         "eslint --fix --no-ignore",
         "git add"
       ],
-      "*.md": "markdownlint"
+      "*.md": [
+        "prettier --write",
+        "markdownlint",
+        "git add"
+      ]
     },
     "ignore": [
       "CHANGELOG.md"

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -6,6 +6,7 @@
     "test:coverage": "echo \"unsupported.\" && exit 1",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
+    "lint:md:fix": "prettier --write \"**/*.md\"",
     "lint": "npm-run-all --print-name --print-label --parallel lint:*",
     "commitmsg": "commitlint -E GIT_PARAMS",
     "precommit": "lint-staged",
@@ -19,7 +20,11 @@
         "eslint --fix --no-ignore",
         "git add"
       ],
-      "*.md": "markdownlint"
+      "*.md": [
+        "prettier --write",
+        "markdownlint",
+        "git add"
+      ]
     },
     "ignore": [
       "CHANGELOG.md"

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -61,6 +61,17 @@ suite('init', () => {
     assert(original === copy)
   })
 
+  test('write ".prettierignore"', async () => {
+    await fixture('package-normal.json')
+    const { stdout, stderr } = await exec('init')
+    assert(stdout.includes('package.json was updated.'))
+    assert(stderr === '')
+
+    const original = await readFile(path.join(originalDir, '.prettierignore'))
+    const copy = await readFile(path.join(workDir, '.prettierignore'))
+    assert(original === copy)
+  })
+
   test('write ".eslintrc.js"', async () => {
     await fixture('package-normal.json')
     const { stdout, stderr } = await exec('init')


### PR DESCRIPTION
* Now `ybiq init` generates `.prettierignore` file
* Now `lint-staged` updates Markdown files via Prettier