### PR TITLE
fix(init): trim `--print-name` option from `npm-run-all`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
     "lint:md:fix": "prettier --write \"**/*.md\"",
-    "lint": "npm-run-all --print-name --print-label --parallel lint:*",
+    "lint": "npm-run-all --print-label --parallel lint:*",
     "commitmsg": "commitlint -E GIT_PARAMS",
     "precommit": "lint-staged",
     "release": "standard-version",

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -7,7 +7,7 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
     "lint:md:fix": "prettier --write \"**/*.md\"",
-    "lint": "npm-run-all --print-name --print-label --parallel lint:*",
+    "lint": "npm-run-all --print-label --parallel lint:*",
     "commitmsg": "commitlint -E GIT_PARAMS",
     "precommit": "lint-staged",
     "release": "standard-version",

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -7,7 +7,7 @@
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
     "lint:md:fix": "prettier --write \"**/*.md\"",
-    "lint": "npm-run-all --print-name --print-label --parallel lint:*",
+    "lint": "npm-run-all --print-label --parallel lint:*",
     "commitmsg": "commitlint -E GIT_PARAMS",
     "precommit": "lint-staged",
     "release": "standard-version",


### PR DESCRIPTION
Giving both `--print-name` and `--print-label` options is too verbose.