### PR TITLE
feat(markdownlint): remove "MD030" rule and enable default option

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,3 @@
 {
-  "MD030": false
+  "default": true
 }


### PR DESCRIPTION
See also <https://github.com/prettier/prettier/issues/4114>