### PR TITLE
feat(init): drop `fs-extra` from runtime dependencies

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,7 +1,12 @@
 const path = require("path");
 const { EOL } = require("os");
-const fs = require("fs-extra");
+const { promisify } = require("util");
+const fs = require("fs");
 const originalPackage = require("../package.json");
+
+const copyFile = promisify(fs.copyFile);
+const writeFile = promisify(fs.writeFile);
+const readFile = promisify(fs.readFile);
 
 const packagePath = (...pathElements) =>
   path.join(...[__dirname, "..", ...pathElements]);
@@ -13,7 +18,7 @@ class Init {
   }
 
   async copyFile(src, dest) {
-    await fs.copy(src, dest);
+    await copyFile(src, dest);
     this.logger(`${dest} was updated.`);
   }
 
@@ -23,12 +28,12 @@ class Init {
 
   async writeFile(fileName, fileContent) {
     const file = this.currentPath(fileName);
-    await fs.writeFile(file, `${fileContent}\n`);
+    await writeFile(file, `${fileContent}\n`);
     this.logger(`${file} was updated.`);
   }
 
   readFile(fileName) {
-    return fs.readFile(this.currentPath(fileName), "utf8");
+    return readFile(this.currentPath(fileName), "utf8");
   }
 
   // eslint-disable-next-line max-statements

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,6 +2580,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -4192,6 +4193,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -7730,7 +7732,8 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,13 @@
     ".markdownlint.json"
   ],
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=8.5.0"
   },
   "dependencies": {
     "@commitlint/cli": "^7.2.1",
     "@commitlint/config-conventional": "^7.1.2",
     "@commitlint/travis-cli": "^7.2.1",
     "eslint": "^5.9.0",
-    "fs-extra": "^7.0.1",
     "husky": "^1.1.4",
     "lint-staged": "^8.0.5",
     "markdownlint-cli": "^0.13.0",
@@ -38,6 +37,7 @@
   },
   "devDependencies": {
     "eslint-config-ybiquitous": "6.2.0",
+    "fs-extra": "^7.0.1",
     "nodemon": "1.18.6",
     "nyc": "13.1.0",
     "tape": "4.9.1"

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,17 +1,17 @@
 const path = require("path");
 const os = require("os");
-const fs = require("fs-extra");
+const fse = require("fs-extra");
 const test = require("tape");
 const pkg = require("../package.json");
 const init = require("../lib/init");
 const exec = require("./helpers/exec");
 
-const readFile = file => fs.readFile(file, "utf8");
-const readJSON = file => fs.readJSON(file, "utf8");
+const readFile = file => fse.readFile(file, "utf8");
+const readJSON = file => fse.readJSON(file, "utf8");
 
 const sandbox = async (fn, t) => {
   const workDir = path.join(os.tmpdir(), `${pkg.name}${Date.now()}`);
-  await fs.mkdirs(workDir);
+  await fse.mkdirs(workDir);
 
   const logMsgs = [];
   const logger = msg => logMsgs.push(msg);
@@ -22,7 +22,7 @@ const sandbox = async (fn, t) => {
     const fixture = async name => {
       const src = fixturePath(name);
       const dest = path.join(workDir, "package.json");
-      await fs.copy(src, dest);
+      await fse.copy(src, dest);
       return dest;
     };
 
@@ -37,7 +37,7 @@ const sandbox = async (fn, t) => {
       initArgs: { cwd: workDir, logger },
     });
   } finally {
-    await fs.remove(workDir);
+    await fse.remove(workDir);
   }
 };
 


### PR DESCRIPTION
Replace `copyFile()` of `fs-extra` with Node.js standard library.

BREAKING CHANGE: drop support Node 8.4- by using `fs.copyFile()`

http://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback