### PR TITLE
feat(remark): migrate from `markdownlint` to `remark-lint`

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -18,7 +18,7 @@ module.exports = {
         "release",
         "init",
         "api",
-        "markdownlint",
+        "remark",
         "travis",
         "prettier",
         "standard-version",

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,0 @@
-{
-  "default": true
-}

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/lib/init.js
+++ b/lib/init.js
@@ -82,7 +82,7 @@ module.exports = async function init({
   const cmd = initCommand(cwd, logger);
   await cmd.updatePackageFile();
   await cmd.writePackageFile(".editorconfig");
-  await cmd.writePackageFile(".markdownlint.json");
+  await cmd.writePackageFile(".remarkignore");
 };
 
 module.exports.desc = `Setup npm project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -418,6 +418,35 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@types/node": {
+      "version": "10.12.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.19.tgz",
+      "integrity": "sha512-2NVovndCjJQj6fUUn9jCgpP4WSqr+u1SoUZMZyJkhGeBFsm6dE46l31S7lPUYt9uQ28XI+ibrJA1f5XyH5HNtA=="
+    },
+    "@types/unist": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.2.tgz",
+      "integrity": "sha512-iHI60IbyfQilNubmxsq4zqSjdynlmc2Q/QvH9kjzg9+CCYVVzq1O6tc7VBzSygIwnmOt07w80IG6HDQvjv3Liw=="
+    },
+    "@types/vfile": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
+      "integrity": "sha512-b3nLFGaGkJ9rzOcuXRfHkZMdjsawuDD0ENL9fzTophtBg8FJHSGbH7daXkEpcwy3v7Xol3pAvsmlYyFhR4pqJw==",
+      "requires": {
+        "@types/node": "*",
+        "@types/unist": "*",
+        "@types/vfile-message": "*"
+      }
+    },
+    "@types/vfile-message": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/vfile-message/-/vfile-message-1.0.1.tgz",
+      "integrity": "sha512-mlGER3Aqmq7bqR1tTTIVHq8KSAFFRyGbrxuM8C/H82g6k7r2fS+IMEkIu3D7JHzG10NvPdR8DNx0jr0pwpp4dA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/unist": "*"
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -490,7 +519,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
@@ -614,8 +642,7 @@
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "dev": true
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
     "atob": {
       "version": "2.1.2",
@@ -656,6 +683,11 @@
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
       }
+    },
+    "bail": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
+      "integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -715,8 +747,7 @@
     "binary-extensions": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
-      "dev": true
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
     "boxen": {
       "version": "1.3.0",
@@ -867,6 +898,11 @@
       "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
       "dev": true
     },
+    "ccount": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
+      "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw=="
+    },
     "chalk": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
@@ -877,6 +913,26 @@
         "supports-color": "^5.2.0"
       }
     },
+    "character-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
+      "integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ=="
+    },
+    "character-entities-html4": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
+      "integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
+      "integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
+      "integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ=="
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -886,7 +942,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
-      "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.0",
@@ -1053,10 +1108,20 @@
         }
       }
     },
+    "co": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
+      "integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1714,11 +1779,6 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
-    "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1843,11 +1903,6 @@
       "requires": {
         "once": "^1.4.0"
       }
-    },
-    "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -2399,8 +2454,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2511,6 +2565,14 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fault": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.2.tgz",
+      "integrity": "sha512-o2eo/X2syzzERAtN5LcGbiVQ0WwZSlN3qLtadwAz3X8Bu+XWD16dja/KMsjZLiQr+BLGPDnHGkc4yUJf1Xpkpw==",
+      "requires": {
+        "format": "^0.2.2"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -2592,6 +2654,11 @@
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
     },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2628,7 +2695,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -2638,25 +2704,20 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -2665,15 +2726,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2682,37 +2739,28 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2721,25 +2769,21 @@
         "deep-extend": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2748,13 +2792,11 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -2770,7 +2812,6 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2784,13 +2825,11 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -2799,7 +2838,6 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -2808,7 +2846,6 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -2817,21 +2854,16 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2839,29 +2871,22 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2870,7 +2895,6 @@
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2879,8 +2903,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2888,13 +2910,11 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -2905,7 +2925,6 @@
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2923,7 +2942,6 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -2933,13 +2951,11 @@
         "npm-bundled": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2949,7 +2965,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -2960,21 +2975,16 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2982,19 +2992,16 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -3004,19 +3011,16 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -3028,7 +3032,6 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "dev": true,
               "optional": true
             }
           }
@@ -3036,7 +3039,6 @@
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3051,7 +3053,6 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -3059,45 +3060,36 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3107,7 +3099,6 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -3116,8 +3107,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3125,13 +3114,11 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -3146,13 +3133,11 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -3160,15 +3145,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3462,6 +3443,21 @@
         "ini": "^1.3.2"
       }
     },
+    "github-slugger": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.2.1.tgz",
+      "integrity": "sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+        }
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -3479,7 +3475,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
       "requires": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -3489,7 +3484,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -3551,11 +3545,6 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "handlebars": {
       "version": "4.0.12",
@@ -3890,6 +3879,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "irregular-plurals": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
+      "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw=="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
@@ -3908,6 +3902,25 @@
         }
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
+      "integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg=="
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
+      "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3917,7 +3930,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -3972,6 +3984,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-decimal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
+      "integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg=="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -3993,6 +4010,11 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+    },
+    "is-empty": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-1.2.0.tgz",
+      "integrity": "sha1-3pu1snhzigWgsJpX4ftNSjQan2s="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -4024,6 +4046,16 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
+      "integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A=="
+    },
+    "is-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-hidden/-/is-hidden-1.1.1.tgz",
+      "integrity": "sha512-175UKecS8+U4hh2PSY0j4xnm2GKYzvSKnbh+naC93JjuBA7LgIo6YxlbcsSo6seFBdQO3RuIcH980yvqqD/2cA=="
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -4063,6 +4095,11 @@
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-observable": {
       "version": "1.1.0",
@@ -4167,10 +4204,20 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "is-whitespace-character": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
+      "integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ=="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "is-word-character": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
+      "integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -4248,6 +4295,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -4298,6 +4353,11 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "levenshtein-edit-distance": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-1.0.0.tgz",
+      "integrity": "sha1-iVuvR4zOi1waDSfkXXwdl4pmHkk="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4305,14 +4365,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "linkify-it": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "requires": {
-        "uc.micro": "^1.0.1"
       }
     },
     "lint-staged": {
@@ -4533,6 +4585,15 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "load-plugin": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/load-plugin/-/load-plugin-2.3.0.tgz",
+      "integrity": "sha512-OxHNMfT3aeHFSpzeMQRcE40kXULv3KA8fGgnySC+rO3Be+0oMWkcRKMJ5zWzUCTuUnabCsQyJzNjo/BLdbmRxA==",
+      "requires": {
+        "npm-prefix": "^1.2.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -4555,18 +4616,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
-    },
-    "lodash.differencewith": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-      "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.template": {
       "version": "4.4.0",
@@ -4602,6 +4652,11 @@
         "cli-cursor": "^2.0.0",
         "wrap-ansi": "^3.0.1"
       }
+    },
+    "longest-streak": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
+      "integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4671,61 +4726,20 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~1.1.1",
-        "linkify-it": "^2.0.0",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      }
+    "markdown-escapes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
+      "integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA=="
     },
-    "markdownlint": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.11.0.tgz",
-      "integrity": "sha512-wE5WdKD6zW2DQaPQ5TFBTXh5j76DnWd/IFffnDQgHmi6Y61DJXBDfLftZ/suJHuv6cwPjM6gKw2GaRLJMOR+Mg==",
-      "requires": {
-        "markdown-it": "8.4.2"
-      }
+    "markdown-extensions": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
+      "integrity": "sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q=="
     },
-    "markdownlint-cli": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.13.0.tgz",
-      "integrity": "sha512-DCjhAIb4EDny6xdjOcu2Rckp1sOSktQU9PjRN2pK9p0Azby7YYBqZXO8I+vhv5XKd2Pk0IbbOhyZ/+zjfH4oww==",
-      "requires": {
-        "commander": "~2.9.0",
-        "deep-extend": "~0.5.1",
-        "get-stdin": "~5.0.1",
-        "glob": "~7.1.2",
-        "js-yaml": "~3.11.0",
-        "lodash.differencewith": "~4.5.0",
-        "lodash.flatten": "~4.4.0",
-        "markdownlint": "~0.11.0",
-        "minimatch": "~3.0.4",
-        "rc": "~1.2.7"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.11.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
-      }
+    "markdown-table": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
+      "integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw=="
     },
     "matcher": {
       "version": "1.1.1",
@@ -4735,6 +4749,37 @@
         "escape-string-regexp": "^1.0.4"
       }
     },
+    "mdast-comment-marker": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-comment-marker/-/mdast-comment-marker-1.1.0.tgz",
+      "integrity": "sha512-NqHAs8nmu08I6MGzpKzgTd9qiCP7oshkyzQrlZxLMsLPUOPjp/Zb/ZtorKD0oOJ38vdZxFCdOlXvlDf77AqEDg=="
+    },
+    "mdast-util-compact": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
+      "integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "mdast-util-definitions": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.3.tgz",
+      "integrity": "sha512-P6wpRO8YVQ1iv30maMc93NLh7COvufglBE8/ldcOyYmk5EbfF0YeqlLgtqP/FOBU501Kqar1x5wYWwB3Nga74g==",
+      "requires": {
+        "unist-util-visit": "^1.0.0"
+      }
+    },
+    "mdast-util-heading-style": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-heading-style/-/mdast-util-heading-style-1.0.4.tgz",
+      "integrity": "sha512-n4fUvwpR5Uj1Ti658KxYDq9gR0UF3FK1UVTVig12imrSOssQU2OpUysje8nps5Cb85b6eau5akpWW7Zkxtv1XA=="
+    },
+    "mdast-util-to-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz",
+      "integrity": "sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A=="
+    },
     "mdn-browser-compat-data": {
       "version": "0.0.54",
       "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.54.tgz",
@@ -4743,11 +4788,6 @@
       "requires": {
         "extend": "3.0.2"
       }
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "mem": {
       "version": "1.1.0",
@@ -4878,7 +4918,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.0.tgz",
       "integrity": "sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==",
-      "dev": true,
       "optional": true
     },
     "nanomatch": {
@@ -4971,7 +5010,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -4982,6 +5020,16 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "requires": {
         "which": "^1.2.10"
+      }
+    },
+    "npm-prefix": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
+      "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
+      "requires": {
+        "rc": "^1.1.0",
+        "shellsubstitute": "^1.1.0",
+        "untildify": "^2.1.0"
       }
     },
     "npm-run-all": {
@@ -5089,7 +5137,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -5414,8 +5461,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -5499,7 +5545,6 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5546,8 +5591,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -5813,8 +5857,7 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -6318,6 +6361,11 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-locale": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -6417,6 +6465,19 @@
         }
       }
     },
+    "parse-entities": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.0.tgz",
+      "integrity": "sha512-XXtDdOPLSB0sHecbEapQi6/58U/ODj/KWfIXmmMCJF/eRn8laX6LZbOyioMoETOOJoWRW8/qTSl5VQkUIfKM5g==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
     "parse-github-repo-url": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -6439,8 +6500,7 @@
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -6555,6 +6615,14 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "plur": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
+      "integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
+      "requires": {
+        "irregular-plurals": "^2.0.0"
+      }
+    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -6614,6 +6682,14 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
       "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+    },
+    "propose": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/propose/-/propose-0.0.5.tgz",
+      "integrity": "sha1-SKBl2ex9TIZn9AULFcSi2F28pWs=",
+      "requires": {
+        "levenshtein-edit-distance": "^1.0.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -6705,7 +6781,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
@@ -6759,11 +6834,738 @@
         "rc": "^1.0.1"
       }
     },
+    "remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-10.0.1.tgz",
+      "integrity": "sha512-E6lMuoLIy2TyiokHprMjcWNJ5UxfGQjaMSMhV+f4idM625UjjK4j798+gPs5mfjzDE6vL0oFKVeZM6gZVSVrzQ==",
+      "requires": {
+        "remark-parse": "^6.0.0",
+        "remark-stringify": "^6.0.0",
+        "unified": "^7.0.0"
+      }
+    },
+    "remark-cli": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/remark-cli/-/remark-cli-6.0.1.tgz",
+      "integrity": "sha512-h7Hwnfdcm5J03t2mxhl9BAav+Goqauqfz3LhpE7TP+RIiPnK6njU7qRDD7qlUd/hLyMSB+WBjYc7gVDQT3pv0A==",
+      "requires": {
+        "markdown-extensions": "^1.1.0",
+        "remark": "^10.0.0",
+        "unified-args": "^6.0.0"
+      }
+    },
+    "remark-lint": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint/-/remark-lint-6.0.4.tgz",
+      "integrity": "sha512-miD6SKhjEkLgdJXgAmNhGsdY1yIGAzwpoGIn/59MR6nZhshdxSm9/pLPiw9fK3loNASA3j7k//kea6x5vHb+jQ==",
+      "requires": {
+        "remark-message-control": "^4.0.0"
+      }
+    },
+    "remark-lint-blockquote-indentation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-blockquote-indentation/-/remark-lint-blockquote-indentation-1.0.2.tgz",
+      "integrity": "sha512-u3ruA+4ZZOpt3YmTCdCOcYiGBMSQ/b/iJvZs/fibF6rwSBmkod48aGGJVoOLMuIuTYYbbXpzigxS+PeJwN0CDQ==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-code-block-style": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-code-block-style/-/remark-lint-code-block-style-1.0.2.tgz",
+      "integrity": "sha512-fTSCga/lJ710zBaD808NwqzAatVoLQFizvXWpetygKwoAfXCyMYQ9DUdDE5jdDhwOu2JPnKbxY+4t6m4SrKKWA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-definition-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-definition-case/-/remark-lint-definition-case-1.0.3.tgz",
+      "integrity": "sha512-ORRDV+ETVWnXoPE3fX0zXFGC5NQvdsB1Ihjeqmw38IWVKnOR34f5s/9BZNnbflBzdKWnLVg1g3IwQLf8eVBsow==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-definition-spacing": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-definition-spacing/-/remark-lint-definition-spacing-1.0.3.tgz",
+      "integrity": "sha512-8lFBtgSE3xbvvSuO95B6lUiD6Ph1wZr5xevKokwwfKoyfOkXDpN85wh7JepIZnUj1OnTXvupCwr7yYUEji/Rrw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-emphasis-marker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-emphasis-marker/-/remark-lint-emphasis-marker-1.0.2.tgz",
+      "integrity": "sha512-c+uvvnYesMaqy/X0dU62dbI6/rk+4dxMXdnfLC/NKBA8GU+4kljWqluW797S6nBG94QZjKIv8m49zJl38QfImQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-fenced-code-flag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-flag/-/remark-lint-fenced-code-flag-1.0.2.tgz",
+      "integrity": "sha512-6/412zYtz+qKpFJryEPSMurWr6tO5MTVohJF3byFc3+3SSEZLWY3Dg8gbwFlumZ9T4HgmfUm/LT7Idm96zj0nw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-fenced-code-marker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-fenced-code-marker/-/remark-lint-fenced-code-marker-1.0.2.tgz",
+      "integrity": "sha512-yAP59Q1JoI1jjOFCn0GoNx4uDji99ROLvdwvmz7+9YR9guDArBcR4i9Wem/wN6apauWPk2DbAZFavHvbZaT8HQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-file-extension": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-file-extension/-/remark-lint-file-extension-1.0.2.tgz",
+      "integrity": "sha512-qx0uki74rmALIKE3r5J3neasbXnz6h+l88OngvpwWkELsnJmfk81JdxfEd0tZ++uTj6CN0TZuhMKad9smfNtRw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-final-definition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-final-definition/-/remark-lint-final-definition-1.0.2.tgz",
+      "integrity": "sha512-F+n8eauYOJGdcSrnD7w2YgQSERx1rAwXTxStaJ2tLmoXlT7eQgpVGHz1U4Y76cg8OANbq8pT0KTNJ85JNqkq4g==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-final-newline": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-final-newline/-/remark-lint-final-newline-1.0.2.tgz",
+      "integrity": "sha512-hW/lbDwVKtME3jIcJWJ16wBtoJdFPWIiu0fEI93yzNTjeB1g3VSWJp66dHbtCLYwquRS5fr8UlGx7JxIu1kiuA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-first-heading-level": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-first-heading-level/-/remark-lint-first-heading-level-1.1.3.tgz",
+      "integrity": "sha512-7dKkiVrzlMoeZJX/TwKIrqaBLYIwGUG5a8sS8dxlGG00LnL2S8koAFL8t/U+dZsfDdF7p0kf4jhcwJWB4U26rA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-hard-break-spaces": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-hard-break-spaces/-/remark-lint-hard-break-spaces-1.0.3.tgz",
+      "integrity": "sha512-GiC0uXeFwef6/Pfo+EYBN0WIVlEFffh+9TdeJ4uLt89ZweaRVDPCTJQqkkuXoiXSPnZGD7cGHdkWCfXU1PaU7Q==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-heading-increment": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-heading-increment/-/remark-lint-heading-increment-1.0.2.tgz",
+      "integrity": "sha512-CE3MmARKFk6LK+nBuOUubhr64LnbJfLNx1gA8XgxWJ4s/gf8yZO23KsaWk3ftVmmwk0d8Eqh4qKg8vvvaMyrWQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-heading-style": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-heading-style/-/remark-lint-heading-style-1.0.2.tgz",
+      "integrity": "sha512-d0aIbL8PU5LWfZVI8p49vEV5wWIfD/DdUjc+O8j5E0UWUgcRgPGB66xznkOb8AiniXpcaYggRW8hGZsxoYNt1g==",
+      "requires": {
+        "mdast-util-heading-style": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-link-title-style": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-link-title-style/-/remark-lint-link-title-style-1.0.3.tgz",
+      "integrity": "sha512-1cJ/gNoIwX36FB0w8TiT+/Cy0evSJRyn0uV0jeB5Ik+fX+tVxHRkuX/DtmFw0fGImQW882r/3eaZHaKabVR1yg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1",
+        "vfile-location": "^2.0.1"
+      }
+    },
+    "remark-lint-list-item-bullet-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-1.0.2.tgz",
+      "integrity": "sha512-zvyQD6mJLRratZjk4Dw7D4vh73L43NXNCcap/6TxcmU9SKO7dXzoh8Ap9tyaFLic0LnHFc3Gx1pqYiPQ7PnL2g==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-list-item-content-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-content-indent/-/remark-lint-list-item-content-indent-1.0.2.tgz",
+      "integrity": "sha512-I7VkspA/jeMmIWZ4cGmW/4oWnT6fP8pn5n11MR7azRMKgooj3N2qGF084UqrWHh/dLJcakJUNl3NTXv1XCS1Mw==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-list-item-indent": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-indent/-/remark-lint-list-item-indent-1.0.3.tgz",
+      "integrity": "sha512-/IcVUPIxQ2X/oCKzqiAtH85CS8An3xQbcMD0DRBHZjBrIUO0Ot7lBiQedSHwCg9lnh7pDOTvHrmNS3FaWjVQqw==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-list-item-spacing": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-spacing/-/remark-lint-list-item-spacing-1.1.2.tgz",
+      "integrity": "sha512-IhG28ofW85o/2+eVH1ft1zgQmjxqDhNp3+217EQLQviPt/+jVcMsua4W4ZQECPg0E9473yiY9TKbBodp2kOMkg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-maximum-heading-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-heading-length/-/remark-lint-maximum-heading-length-1.0.2.tgz",
+      "integrity": "sha512-kDdwgRItpVGhxdUC+kbWn5YisCrtF4KggP8z36z26tBmDuPj1ohjQvfMWY0oKL8I0Y6UuXyE0vQx3m4R8Qrj+A==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-maximum-line-length": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-maximum-line-length/-/remark-lint-maximum-line-length-1.1.1.tgz",
+      "integrity": "sha512-lqvUBSkKNZJyDnZGlg765OKDNtUgYEPma7BzxdF5JFoYxxOR2V0WyAfnw7VbuZxEmX4UjHmrfAmgOKmybP1hbA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-no-auto-link-without-protocol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-auto-link-without-protocol/-/remark-lint-no-auto-link-without-protocol-1.0.2.tgz",
+      "integrity": "sha512-3GtkSxOyd6we4b8JdtJsNgt8+3UN+hpw1UiMoE9X96ahc1rqsCFm6miorNUnF/gfPQ1liHBvZUed2SIenDmpkg==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-blockquote-without-marker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-2.0.2.tgz",
+      "integrity": "sha512-jkfZ4hFiviZttEo7Ac7GZWFgMQ/bdVPfSluLeuf+qwL8sQvR4ClklKJ0Xbkk3cLRjvlGsc8U8uZR8qqH5MSLoA==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1",
+        "vfile-location": "^2.0.1"
+      }
+    },
+    "remark-lint-no-consecutive-blank-lines": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-consecutive-blank-lines/-/remark-lint-no-consecutive-blank-lines-1.0.2.tgz",
+      "integrity": "sha512-KbOm6EX5Yl9uzRC93soTB+HlqtCzu9XJWsV9CVcoDKtNnpKfyTwQOy6dmUbQrLp4xBdNk4s9S9CsemRaHEkFGA==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-duplicate-definitions": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.3.tgz",
+      "integrity": "sha512-8iQhawbIMwQILRpCsoYCVYrSF2rrWEfF7KPvIIJavp0TA02Wv+SX7b3hQslNtvso0Ka2VX+kI1+x+QzG16Duqg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-stringify-position": "^1.1.2",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-no-duplicate-headings": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-headings/-/remark-lint-no-duplicate-headings-1.0.2.tgz",
+      "integrity": "sha512-RO3/eQxLjUoHirHIVC+bE5Abzl+gWiJcdPr48gGSP34xfwCeaBAaeorOAxY/hOqOQ/EVNTTA/JHCBVSNPZWIeg==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-stringify-position": "^1.1.2",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-emphasis-as-heading": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-emphasis-as-heading/-/remark-lint-no-emphasis-as-heading-1.0.2.tgz",
+      "integrity": "sha512-lKlwiRQOFOoPSwjbZf065RaUr6RZmO82zZYjXhVT9xwMkWXIAQyG0GJuLB2/+rlMEtlgoUD3ePch+Pzf+KrSJQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-file-name-articles": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-articles/-/remark-lint-no-file-name-articles-1.0.2.tgz",
+      "integrity": "sha512-5FuxJ0Hd2AgVSP1javG51qPbMBWxma1LrCKI6JmBsu/GM7ZYOgemMyH5v4I1ejTPGj7P30xmIjMNSnV8IBMq3g==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-consecutive-dashes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-consecutive-dashes/-/remark-lint-no-file-name-consecutive-dashes-1.0.2.tgz",
+      "integrity": "sha512-VvCxG3AfRm6ROFNJ8+tdOOkk61mEKj+PytB8xg5WNQypKWhhJ734mJ3GzXD4XEov7Bdd1GVXJFXlLFtfoAewHw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-irregular-characters": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-irregular-characters/-/remark-lint-no-file-name-irregular-characters-1.0.2.tgz",
+      "integrity": "sha512-8A+DYXsiPBu0q4cvqtYwzRj6SWrKnPh+oI1H1t64pCQiSnLmG9e3mAUXMxH9PiM6y5OW7Vw8Xh4KYsnRwGEuMQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-mixed-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-mixed-case/-/remark-lint-no-file-name-mixed-case-1.0.2.tgz",
+      "integrity": "sha512-OMH2kpjvDAsyyw8ar9h6WI1kUXSpQ2r2c5JZv3NBNYxwzTBfhCR2MSQq+eEI7yUmD2ehqNUY5LwZTQZG6cK4vw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-file-name-outer-dashes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-file-name-outer-dashes/-/remark-lint-no-file-name-outer-dashes-1.0.3.tgz",
+      "integrity": "sha512-imUWm8Bi9PxV+IQtQC2/BV1Yj0VboC9hPMZh3sae8pZvCjXquTyYiSFa7hQxX6KWCNUiRPHMSlaSVvfvM2e4pQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0"
+      }
+    },
+    "remark-lint-no-heading-content-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-1.0.2.tgz",
+      "integrity": "sha512-g2MVmJhHbfFungca5WGWVB9bBY4YTrY6og20U+6DxkdS4ngoc8ezXUt8zV1HHEn0M/GdKr9F7fYhXcekJd/qaw==",
+      "requires": {
+        "mdast-util-heading-style": "^1.0.2",
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-heading-punctuation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-heading-punctuation/-/remark-lint-no-heading-punctuation-1.0.2.tgz",
+      "integrity": "sha512-nYc2a0ihQ5cPy7elaM0lRPYKEMpEK6EjyJH6pHYlgG8NQwjKXhsVaek0fmAm12PaYoYOGW1pDxfzxnFUocU20g==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-inline-padding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-1.0.3.tgz",
+      "integrity": "sha512-zEe7LjM13kQshdBtPnSzzCUNzGIX/XiGspMb7HZBCDWYsPJ73s01X+m+YI99Dz7wKvB3EUTZ7/MFhTUIvqcGRw==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-no-literal-urls": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-literal-urls/-/remark-lint-no-literal-urls-1.0.2.tgz",
+      "integrity": "sha512-+mWZIJA4yAqpKIclcFP5wRy/6hxcPnfU9Xmgp4fR7OD4JQ4JHkKq9O7MUbda14PLez1aMX+Is0O0hWI7OuqsSw==",
+      "requires": {
+        "mdast-util-to-string": "^1.0.2",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-multiple-toplevel-headings": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-multiple-toplevel-headings/-/remark-lint-no-multiple-toplevel-headings-1.0.2.tgz",
+      "integrity": "sha512-Zxkw7wIyMOyYQb5C5NTswSttZPCLqm/60Wnt0TEWzXVDkVk5DrxrCCxbMKgpXve1Co5CXPmMixNr/xYBqzxzWg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-stringify-position": "^1.1.2",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-shell-dollars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-shell-dollars/-/remark-lint-no-shell-dollars-1.0.2.tgz",
+      "integrity": "sha512-eIjBebX9iOFWbMdjol5JJBXI7ku+7UyJpNrd++rl8QenLLZ76beh+xONCzJw/k5dhEw5voBmQLh7VK9HPU/ang==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-shortcut-reference-image": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-shortcut-reference-image/-/remark-lint-no-shortcut-reference-image-1.0.2.tgz",
+      "integrity": "sha512-IVYv5pgyf70jYcrn+BNHVO37BuQJg26rFOLzi2mj+/8EdFpolJiJcTvkChJgz5yip7317DmQQSNLX6gCExuDrQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-shortcut-reference-link": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-shortcut-reference-link/-/remark-lint-no-shortcut-reference-link-1.0.3.tgz",
+      "integrity": "sha512-v5mk4wYQL+YRmlOTqi8avpzhoGZg+P42dDRda2jedysDIx7TJBEXUH6oMFEbo/qV6PMmtr7fr066M3RrOrLpiQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-no-table-indentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-table-indentation/-/remark-lint-no-table-indentation-1.0.3.tgz",
+      "integrity": "sha512-argI2JADlVrlwsdORdbmE89QXB9XtBtAy2YBHZv/q/d247CyL+h+hw9wpg06P1lLQwbllxYJD5u1bNtfgv3XVg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-no-tabs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-tabs/-/remark-lint-no-tabs-1.0.2.tgz",
+      "integrity": "sha512-jPjRLHyzO4lO6orhOmHd6AN6mVc/uMWvYZ3qD41dniktnLyHEbIG6DpPxixjfpmEe0wi73RXMywKHrWshLJwAg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "vfile-location": "^2.0.1"
+      }
+    },
+    "remark-lint-no-undefined-references": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-1.0.3.tgz",
+      "integrity": "sha512-yQxSpTQ3aGY4aszGSktAzeBC+h/k/YR/bf4ATrjCK5dz4C3InodCcrW/mtarLHR/3/kvM7NcGiOl0PElKJW5mg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-no-unused-definitions": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-unused-definitions/-/remark-lint-no-unused-definitions-1.0.4.tgz",
+      "integrity": "sha512-wKh10+2hiVKEkVXfW5zC8lyDCJQM6lpyRsyIVxq0ROHkrAjsO+seljEQCOsIJ55nZHbdCOCFDQosA0/5wgryRw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-ordered-list-marker-style": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-style/-/remark-lint-ordered-list-marker-style-1.0.2.tgz",
+      "integrity": "sha512-4EHuHxZqy8IT4k+4Vc8P38I34AiZfgl07fS5/iqGhCdoSMCvvxdOuzTWTgpDFbx/W2QpHelBfJ+FtOp+E0J4Lg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-ordered-list-marker-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-ordered-list-marker-value/-/remark-lint-ordered-list-marker-value-1.0.2.tgz",
+      "integrity": "sha512-vIPD07u+FBjTjEETZ+UWUp2nydzvOe5AHIX812JlNXWuHYuCybq8DGnkYUcoiK3HbIE+KdG+e7C5xHkim0PSjw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-rule-style": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-rule-style/-/remark-lint-rule-style-1.0.2.tgz",
+      "integrity": "sha512-D9mMPKA7rtCe4Yx+ryip6FyfNG9uGOaHxRgJClfte7D66QzxiiWtHYyNCXI4rkv8Ax9PrEdpWCPcIl3D2LrXhw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-strong-marker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-strong-marker/-/remark-lint-strong-marker-1.0.2.tgz",
+      "integrity": "sha512-oUSKqYJVLgbXe25NmcTOfQ8wsFasc+qhEoGjPEGPuJMV2aZIGuOEbGVqD5B1ckYGBEwbTuet3btvMohz8HaBDQ==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-table-cell-padding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-cell-padding/-/remark-lint-table-cell-padding-1.0.3.tgz",
+      "integrity": "sha512-beXwMK8KAGIDQWixf7wzte4GhyB9w33DxTGgmP4HWOWMVXHvBnufJvnIozBBOH9nOsi1fP8NYRb/01hrgjNnmw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.4.0"
+      }
+    },
+    "remark-lint-table-pipe-alignment": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-pipe-alignment/-/remark-lint-table-pipe-alignment-1.0.2.tgz",
+      "integrity": "sha512-gLJwduvBI2soR7Dyf39KGUl3M9ZCK/7pFfWBeOv8J27D7px/1lXooqlX4Y9NQ/+9jc7DyLF9upPxh7UWm7UXGg==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-table-pipes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-table-pipes/-/remark-lint-table-pipes-1.0.2.tgz",
+      "integrity": "sha512-BGKcOviuUC6fILIOPYFe6awqk57ApzNJpK3OYBrweGoFF55nZ/qf3q6JpzA0chd6wKj7VrcfQEd3QSQQ+8Wcrw==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-lint-unordered-list-marker-style": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-unordered-list-marker-style/-/remark-lint-unordered-list-marker-style-1.0.2.tgz",
+      "integrity": "sha512-qdnF9JuMWzFJzGIfdAWfOHyjad8dqIQSs+cTzqMlNZHOGrrCJdTUWzybzcZMGn1yuwreklZdHKhOglXQFwSD3A==",
+      "requires": {
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
+    "remark-message-control": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/remark-message-control/-/remark-message-control-4.1.1.tgz",
+      "integrity": "sha512-DojJPPeSux/U7aHCN6GUWBgp6F1EQFPUNvnk2gfuGgiMCHVubz/xAC3TkvPaf5w1F0PEGaOEpCtvxJK6O4Kmiw==",
+      "requires": {
+        "mdast-comment-marker": "^1.0.0",
+        "unified-message-control": "^1.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-parse": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-preset-lint-markdown-style-guide": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-markdown-style-guide/-/remark-preset-lint-markdown-style-guide-2.1.2.tgz",
+      "integrity": "sha512-0mYeeO084o3ZuDSQCvj5vpMZEGQ/HxPcO5vdNpicu+wKpuGNKV2hYZeHbXa/uZV0gjiQeuRmCHIDgNaDsMj5fg==",
+      "requires": {
+        "remark-lint": "^6.0.0",
+        "remark-lint-blockquote-indentation": "^1.0.0",
+        "remark-lint-code-block-style": "^1.0.0",
+        "remark-lint-definition-case": "^1.0.0",
+        "remark-lint-definition-spacing": "^1.0.0",
+        "remark-lint-emphasis-marker": "^1.0.0",
+        "remark-lint-fenced-code-flag": "^1.0.0",
+        "remark-lint-fenced-code-marker": "^1.0.0",
+        "remark-lint-file-extension": "^1.0.0",
+        "remark-lint-final-definition": "^1.0.0",
+        "remark-lint-hard-break-spaces": "^1.0.0",
+        "remark-lint-heading-increment": "^1.0.0",
+        "remark-lint-heading-style": "^1.0.0",
+        "remark-lint-link-title-style": "^1.0.0",
+        "remark-lint-list-item-content-indent": "^1.0.0",
+        "remark-lint-list-item-indent": "^1.0.0",
+        "remark-lint-list-item-spacing": "^1.0.0",
+        "remark-lint-maximum-heading-length": "^1.0.0",
+        "remark-lint-maximum-line-length": "^1.0.0",
+        "remark-lint-no-auto-link-without-protocol": "^1.0.0",
+        "remark-lint-no-blockquote-without-marker": "^2.0.0",
+        "remark-lint-no-consecutive-blank-lines": "^1.0.0",
+        "remark-lint-no-duplicate-headings": "^1.0.0",
+        "remark-lint-no-emphasis-as-heading": "^1.0.0",
+        "remark-lint-no-file-name-articles": "^1.0.0",
+        "remark-lint-no-file-name-consecutive-dashes": "^1.0.0",
+        "remark-lint-no-file-name-irregular-characters": "^1.0.0",
+        "remark-lint-no-file-name-mixed-case": "^1.0.0",
+        "remark-lint-no-file-name-outer-dashes": "^1.0.0",
+        "remark-lint-no-heading-punctuation": "^1.0.0",
+        "remark-lint-no-inline-padding": "^1.0.0",
+        "remark-lint-no-literal-urls": "^1.0.0",
+        "remark-lint-no-multiple-toplevel-headings": "^1.0.0",
+        "remark-lint-no-shell-dollars": "^1.0.0",
+        "remark-lint-no-shortcut-reference-image": "^1.0.0",
+        "remark-lint-no-shortcut-reference-link": "^1.0.0",
+        "remark-lint-no-table-indentation": "^1.0.0",
+        "remark-lint-ordered-list-marker-style": "^1.0.0",
+        "remark-lint-ordered-list-marker-value": "^1.0.0",
+        "remark-lint-rule-style": "^1.0.0",
+        "remark-lint-strong-marker": "^1.0.0",
+        "remark-lint-table-cell-padding": "^1.0.0",
+        "remark-lint-table-pipe-alignment": "^1.0.0",
+        "remark-lint-table-pipes": "^1.0.0",
+        "remark-lint-unordered-list-marker-style": "^1.0.0"
+      }
+    },
+    "remark-preset-lint-recommended": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-3.0.2.tgz",
+      "integrity": "sha512-os4YNWLbkorjvDHVB4o+zCCufZLzGoD4Iwdk7SV7bSIZurUTrMp/ZrpNytyetN9ugIMXuHbWJUE+dF0ND+WorQ==",
+      "requires": {
+        "remark-lint": "^6.0.0",
+        "remark-lint-final-newline": "^1.0.0",
+        "remark-lint-hard-break-spaces": "^1.0.0",
+        "remark-lint-list-item-bullet-indent": "^1.0.0",
+        "remark-lint-list-item-indent": "^1.0.0",
+        "remark-lint-no-auto-link-without-protocol": "^1.0.0",
+        "remark-lint-no-blockquote-without-marker": "^2.0.0",
+        "remark-lint-no-duplicate-definitions": "^1.0.0",
+        "remark-lint-no-heading-content-indent": "^1.0.0",
+        "remark-lint-no-inline-padding": "^1.0.0",
+        "remark-lint-no-literal-urls": "^1.0.0",
+        "remark-lint-no-shortcut-reference-image": "^1.0.0",
+        "remark-lint-no-shortcut-reference-link": "^1.0.0",
+        "remark-lint-no-undefined-references": "^1.0.0",
+        "remark-lint-no-unused-definitions": "^1.0.0",
+        "remark-lint-ordered-list-marker-style": "^1.0.0"
+      }
+    },
+    "remark-stringify": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-6.0.4.tgz",
+      "integrity": "sha512-eRWGdEPMVudijE/psbIDNcnJLRVx3xhfuEsTDGgH4GsFF91dVhw5nhmnBppafJ7+NWINW6C7ZwWbi30ImJzqWg==",
+      "requires": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^1.1.0",
+        "mdast-util-compact": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^1.0.1",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      }
+    },
+    "remark-validate-links": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/remark-validate-links/-/remark-validate-links-8.0.0.tgz",
+      "integrity": "sha512-S9255mpPMLGKC5xHTgmJOcbKjUGXwag+5VBBbOZqkmstfg7wDnElgsGDOkOeqzSIrlq8Oom+aXTy/Pds3Lhhgg==",
+      "requires": {
+        "github-slugger": "^1.2.0",
+        "hosted-git-info": "^2.5.0",
+        "mdast-util-definitions": "^1.0.0",
+        "mdast-util-to-string": "^1.0.4",
+        "propose": "0.0.5",
+        "unist-util-visit": "^1.0.0",
+        "urljoin": "^0.1.5",
+        "xtend": "^4.0.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -6782,6 +7584,11 @@
       "requires": {
         "is-finite": "^1.0.0"
       }
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -6980,6 +7787,11 @@
         "jsonify": "~0.0.0"
       }
     },
+    "shellsubstitute": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
+      "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -7007,6 +7819,11 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -7342,6 +8159,11 @@
         }
       }
     },
+    "state-toggle": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
+      "integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -7402,6 +8224,17 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-entities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+      "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "stringify-object": {
@@ -7611,6 +8444,22 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "to-vfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-4.0.0.tgz",
+      "integrity": "sha512-Y7EDM+uoU8TZxF5ej2mUR0dLO4qbuuNRnJKxEht2QJWEq2421pyG1D1x8YxPKmyTc6nHh7Td/jLGFxYo+9vkLA==",
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "vfile": "^3.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
     "toposort": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
@@ -7624,6 +8473,11 @@
       "requires": {
         "nopt": "~1.0.10"
       }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "2.0.0",
@@ -7640,6 +8494,16 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
+      "integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg=="
+    },
+    "trough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
+      "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw=="
     },
     "tslib": {
       "version": "1.9.3",
@@ -7658,11 +8522,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -7714,6 +8573,111 @@
         }
       }
     },
+    "unherit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
+      "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
+      }
+    },
+    "unified": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "@types/vfile": "^3.0.0",
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^3.0.0",
+        "x-is-string": "^0.1.0"
+      }
+    },
+    "unified-args": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unified-args/-/unified-args-6.0.0.tgz",
+      "integrity": "sha512-1m2pGiTClgcCtCvgtABkJLze8JJiZpzsqujRhzBjZsRwaIIU1Yj36YHY6t2RvidO8d6fucZdk3KX+8eS4+uv9g==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "chalk": "^2.0.0",
+        "chokidar": "^2.0.0",
+        "fault": "^1.0.2",
+        "json5": "^1.0.0",
+        "minimist": "^1.2.0",
+        "text-table": "^0.2.0",
+        "unified-engine": "^6.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+        }
+      }
+    },
+    "unified-engine": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unified-engine/-/unified-engine-6.0.1.tgz",
+      "integrity": "sha512-iDJYH82TgcezQA4IZzhCNJQx7vBsGk4h9s4Q7Fscrb3qcPsxBqVrVNYez2W3sBVTxuU1bFAhyRpA6ba/R4j93A==",
+      "requires": {
+        "concat-stream": "^1.5.1",
+        "debug": "^3.1.0",
+        "fault": "^1.0.0",
+        "fn-name": "^2.0.1",
+        "glob": "^7.0.3",
+        "ignore": "^3.2.0",
+        "is-empty": "^1.0.0",
+        "is-hidden": "^1.0.1",
+        "is-object": "^1.0.1",
+        "js-yaml": "^3.6.1",
+        "load-plugin": "^2.0.0",
+        "parse-json": "^4.0.0",
+        "to-vfile": "^4.0.0",
+        "trough": "^1.0.0",
+        "unist-util-inspect": "^4.1.2",
+        "vfile-reporter": "^5.0.0",
+        "vfile-statistics": "^1.1.0",
+        "x-is-string": "^0.1.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+        }
+      }
+    },
+    "unified-lint-rule": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/unified-lint-rule/-/unified-lint-rule-1.0.3.tgz",
+      "integrity": "sha512-6z+HH3mtlFdj/w3MaQpObrZAd9KRiro370GxBFh13qkV8LYR21lLozA4iQiZPhe7KuX/lHewoGOEgQ4AWrAR3Q==",
+      "requires": {
+        "wrapped": "^1.0.1"
+      }
+    },
+    "unified-message-control": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unified-message-control/-/unified-message-control-1.0.4.tgz",
+      "integrity": "sha512-e1dEtN4Z/TvLn/qHm+xeZpzqhJTtfZusFErk336kkZVpqrJYiV9ptxq+SbRPFMlN0OkjDYHmVJ929KYjsMTo3g==",
+      "requires": {
+        "trim": "0.0.1",
+        "unist-util-visit": "^1.0.0",
+        "vfile-location": "^2.0.0"
+      }
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
@@ -7753,6 +8717,58 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "unist-util-generated": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.3.tgz",
+      "integrity": "sha512-qlPeDqnQnd84KIqwphzOR+l02cxjDzvEYEBl84EjmKRrX4eUmjyAo8xJv1SCDhJqNjyHRnBMZWNKAiBtXE6hBg=="
+    },
+    "unist-util-inspect": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/unist-util-inspect/-/unist-util-inspect-4.1.3.tgz",
+      "integrity": "sha512-Fv9R88ZBbDp7mHN+wsbxS1r8VW3unyhZh/F18dcJRQsg0+g3DxNQnMS+AEG/uotB8Md+HMK/TfzSU5lUDWxkZg==",
+      "requires": {
+        "is-empty": "^1.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+      "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+    },
+    "unist-util-position": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.0.2.tgz",
+      "integrity": "sha512-npmFu92l/+b1Ao6uGP4I1WFz9hsKv7qleZ4aliw6x0RVu6A9A3tAf57NMpFfzQ02jxRtJZuRn+C8xWT7GWnH0g=="
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
+      "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+    },
+    "unist-util-visit": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+      "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
+      "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+      "requires": {
+        "unist-util-is": "^2.1.2"
       }
     },
     "universalify": {
@@ -7797,6 +8813,14 @@
         }
       }
     },
+    "untildify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
@@ -7806,8 +8830,7 @@
     "upath": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
-      "dev": true
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw=="
     },
     "update-notifier": {
       "version": "2.5.0",
@@ -7849,6 +8872,21 @@
         "prepend-http": "^1.0.1"
       }
     },
+    "urljoin": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/urljoin/-/urljoin-0.1.5.tgz",
+      "integrity": "sha1-sl0sYRLFWsnVAJakmg8ft/T1OSE=",
+      "requires": {
+        "extend": "~2.0.0"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+          "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
+        }
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -7867,6 +8905,60 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
+      "integrity": "sha512-y7Y3gH9BsUSdD4KzHsuMaCzRjglXN0W2EcMf0gpvu6+SbsGhMje7xDc8AEoeXy6mIwCKMI6BkjMsRjzQbhMEjQ==",
+      "requires": {
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
+      "integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w=="
+    },
+    "vfile-message": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "requires": {
+        "unist-util-stringify-position": "^1.1.1"
+      }
+    },
+    "vfile-reporter": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-5.1.1.tgz",
+      "integrity": "sha512-A/cfKvfVmeEmAKx1yyOWggCjC/k184Vkl5pVJAw5CEdppHd5FHBVcdyJ1JBSqIdJjJqyhZY4ZD3JycHr/uwmlA==",
+      "requires": {
+        "repeat-string": "^1.5.0",
+        "string-width": "^2.0.0",
+        "supports-color": "^5.4.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-sort": "^2.1.2",
+        "vfile-statistics": "^1.1.0"
+      }
+    },
+    "vfile-sort": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-2.2.0.tgz",
+      "integrity": "sha512-RgxLXVWrJBWb2GuP8FsSkqK7HmbjXjnI8qx3nD6NTWhsWaelaKvJuxfh1F1d1lkCPD7imo4zzi8cf6IOMgaTnQ=="
+    },
+    "vfile-statistics": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vfile-statistics/-/vfile-statistics-1.1.2.tgz",
+      "integrity": "sha512-16wAC9eEGXdsD35LX9m/iXCRIZyX5LIrDgDtAF92rbATSqsBRbC4n05e0Rj5vt3XRpcKu0UJeWnTxWsSyvNZ+w=="
     },
     "which": {
       "version": "1.3.1",
@@ -7904,6 +8996,15 @@
         "strip-ansi": "^4.0.0"
       }
     },
+    "wrapped": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wrapped/-/wrapped-1.0.1.tgz",
+      "integrity": "sha1-x4PZ2Aeyc+mwHoUWgKk4yHyQckI=",
+      "requires": {
+        "co": "3.1.0",
+        "sliced": "^1.0.1"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -7927,6 +9028,11 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
       }
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xdg-basedir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bin",
     "lib",
     ".editorconfig",
-    ".markdownlint.json"
+    ".remarkignore"
   ],
   "engines": {
     "node": ">=8.5.0"
@@ -29,9 +29,14 @@
     "eslint": "^5.12.1",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.1",
-    "markdownlint-cli": "^0.13.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.16.1",
+    "remark-cli": "^6.0.1",
+    "remark-lint-first-heading-level": "^1.1.3",
+    "remark-lint-no-tabs": "^1.0.2",
+    "remark-preset-lint-markdown-style-guide": "^2.1.2",
+    "remark-preset-lint-recommended": "^3.0.2",
+    "remark-validate-links": "^8.0.0",
     "standard-version": "^4.4.0",
     "yargs": "^12.0.5"
   },
@@ -48,12 +53,13 @@
     "test:coverage": "nyc report --reporter=html",
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
-    "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
+    "lint:md": "remark . --frail",
+    "lint:md:fix": "npm run lint:md -- --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mjs,scss,yaml,yml}\"",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
-    "format": "npm-run-all --print-label --parallel lint:js:fix prettier:write",
+    "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
     "release": "standard-version --sign",
     "release:dry-run": "npm run release -- --dry-run"
   },
@@ -70,7 +76,8 @@
         "git add"
       ],
       "*.md": [
-        "markdownlint --ignore CHANGELOG.md"
+        "remark --output",
+        "git add"
       ],
       "*.{html,json,md,yaml,yml}": [
         "prettier --write",
@@ -85,6 +92,15 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
+  },
+  "remarkConfig": {
+    "plugins": [
+      "remark-preset-lint-markdown-style-guide",
+      "remark-preset-lint-recommended",
+      "remark-lint-first-heading-level",
+      "remark-lint-no-tabs",
+      "remark-validate-links"
+    ]
   },
   "browserslist": [
     "> 1%",

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -5,12 +5,13 @@
     "test:coverage": "echo \"unsupported.\" && exit 1",
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
-    "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
+    "lint:md": "remark . --frail",
+    "lint:md:fix": "npm run lint:md -- --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mjs,scss,yaml,yml}\"",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
-    "format": "npm-run-all --print-label --parallel lint:js:fix prettier:write",
+    "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
     "release": "standard-version --sign",
     "release:dry-run": "npm run release -- --dry-run"
   },
@@ -23,7 +24,7 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,mjs}": ["eslint --fix --no-ignore", "git add"],
-      "*.md": ["markdownlint --ignore CHANGELOG.md"],
+      "*.md": ["remark --output", "git add"],
       "*.{html,json,md,yaml,yml}": ["prettier --write", "git add"]
     }
   },

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -5,12 +5,13 @@
     "test:watch": "abc --watch",
     "test:coverage": "echo \"unsupported.\" && exit 1",
     "lint:js:fix": "npm run lint:js -- --fix",
-    "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
+    "lint:md": "remark . --frail",
+    "lint:md:fix": "npm run lint:md -- --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mjs,scss,yaml,yml}\"",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
-    "format": "npm-run-all --print-label --parallel lint:js:fix prettier:write",
+    "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
     "release": "standard-version --sign",
     "release:dry-run": "npm run release -- --dry-run"
   },
@@ -24,7 +25,7 @@
     "*.css": "xyz",
     "linters": {
       "*.{js,jsx,mjs}": ["eslint --fix --no-ignore", "git add"],
-      "*.md": ["markdownlint --ignore CHANGELOG.md"],
+      "*.md": ["remark --output", "git add"],
       "*.{html,json,md,yaml,yml}": ["prettier --write", "git add"]
     }
   },

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -64,7 +64,7 @@ test("init", t => {
     t.end();
   });
 
-  [".editorconfig", ".markdownlint.json"].forEach(file => {
+  [".editorconfig", ".remarkignore"].forEach(file => {
     testInSandbox(`write "${file}"`, async (t, ctx) => {
       await ctx.fixture("package-normal.json");
       await init(ctx.initArgs);


### PR DESCRIPTION
BREAKING CHANGE: `markdownlint` is unsupported no longer. It may fail linting your Markdown files.

See also:

- https://github.com/remarkjs/remark-lint
- https://github.com/remarkjs/remark-lint/blob/master/doc/comparison-to-markdownlint.md
- https://github.com/DavidAnson/markdownlint