### PR TITLE
fix(standard-version): add `--no-verify` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
-    "release": "standard-version --sign",
+    "release": "standard-version --sign --no-verify",
     "release:dry-run": "npm run release -- --dry-run"
   },
   "husky": {

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -12,7 +12,7 @@
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
-    "release": "standard-version --sign",
+    "release": "standard-version --sign --no-verify",
     "release:dry-run": "npm run release -- --dry-run"
   },
   "husky": {

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -12,7 +12,7 @@
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
-    "release": "standard-version --sign",
+    "release": "standard-version --sign --no-verify",
     "release:dry-run": "npm run release -- --dry-run"
   },
   "husky": {


### PR DESCRIPTION
Why? - Because `pre-commit` hook does many things now, which are unnecessary for the release task.