### PR TITLE
fix(remark): fix settings & scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
-    "lint:md:fix": "npm run lint:md -- --output",
+    "lint:md:fix": "remark . --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}\"",
     "prettier:check": "npm run prettier -- --check",
@@ -76,7 +76,7 @@
         "git add"
       ],
       "*.md": [
-        "remark --output",
+        "remark --output --",
         "git add"
       ],
       "*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}": [
@@ -102,6 +102,14 @@
       "remark-preset-lint-recommended",
       "remark-lint-first-heading-level",
       "remark-lint-no-tabs",
+      [
+        "remark-lint-list-item-spacing",
+        false
+      ],
+      [
+        "remark-lint-ordered-list-marker-value",
+        "ordered"
+      ],
       "remark-validate-links"
     ]
   },

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -6,7 +6,7 @@
     "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs .",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
-    "lint:md:fix": "npm run lint:md -- --output",
+    "lint:md:fix": "remark . --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}\"",
     "prettier:check": "npm run prettier -- --check",
@@ -24,7 +24,7 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,mjs}": ["eslint --fix --no-ignore", "git add"],
-      "*.md": ["remark --output", "git add"],
+      "*.md": ["remark --output --", "git add"],
       "*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}": ["prettier --write", "git add"]
     },
     "ignore": ["CHANGELOG.md"]
@@ -43,6 +43,8 @@
       "remark-preset-lint-recommended",
       "remark-lint-first-heading-level",
       "remark-lint-no-tabs",
+      ["remark-lint-list-item-spacing", false],
+      ["remark-lint-ordered-list-marker-value", "ordered"],
       "remark-validate-links"
     ]
   },

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -6,7 +6,7 @@
     "test:coverage": "echo \"unsupported.\" && exit 1",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
-    "lint:md:fix": "npm run lint:md -- --output",
+    "lint:md:fix": "remark . --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
     "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}\"",
     "prettier:check": "npm run prettier -- --check",
@@ -25,7 +25,7 @@
     "*.css": "xyz",
     "linters": {
       "*.{js,jsx,mjs}": ["eslint --fix --no-ignore", "git add"],
-      "*.md": ["remark --output", "git add"],
+      "*.md": ["remark --output --", "git add"],
       "*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}": ["prettier --write", "git add"]
     },
     "ignore": ["CHANGELOG.md"]
@@ -44,6 +44,8 @@
       "remark-preset-lint-recommended",
       "remark-lint-first-heading-level",
       "remark-lint-no-tabs",
+      ["remark-lint-list-item-spacing", false],
+      ["remark-lint-ordered-list-marker-value", "ordered"],
       "remark-validate-links"
     ]
   },


### PR DESCRIPTION
Because some `remark-lint` rules conflicts with Prettier.