### PR TITLE
test: fix unstable `help` test by locale on localhost

### DIFF
--- a/test/helpers/exec.js
+++ b/test/helpers/exec.js
@@ -5,7 +5,7 @@ const tested = path.join(process.cwd(), "bin", "cli.js");
 
 module.exports = function exec(...args) {
   const options = {
-    env: { ...process.env, LANG: "C" },
+    env: { ...process.env, LC_ALL: "C" },
   };
   const lastArg = args[args.length - 1];
   if (lastArg && typeof lastArg === "object") {


### PR DESCRIPTION
The `yargs` package depends on the `os-locale` package to guess the locale.
The `os-locale` package prioritizes `LC_ALL` over `LANG`.

See below:
- https://github.com/yargs/yargs/blob/51876e69c71e9861fb09847530eeaec9be534f5f/yargs.js#L1184
- https://github.com/sindresorhus/os-locale/blob/22e9f2e66e1493ffda58c9ed8f936f554bccb76f/index.js#L10