### PR TITLE
feat(remark): remove `remark-lint-first-heading-level` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6768,16 +6768,6 @@
         "unified-lint-rule": "^1.0.0"
       }
     },
-    "remark-lint-first-heading-level": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/remark-lint-first-heading-level/-/remark-lint-first-heading-level-1.1.4.tgz",
-      "integrity": "sha512-iU5G4ZmGx8/2p/U2rPc6qhjyQ/BCcOuj07KzI7XxapYfJqZF6Xxz2rC2b/5xsDJAz2vXG74U4iG3c9vmbyH9WQ==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^1.4.0"
-      }
-    },
     "remark-lint-hard-break-spaces": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/remark-lint-hard-break-spaces/-/remark-lint-hard-break-spaces-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "remark-cli": "^6.0.1",
-    "remark-lint-first-heading-level": "^1.1.4",
     "remark-lint-no-tabs": "^1.0.3",
     "remark-preset-lint-markdown-style-guide": "^2.1.3",
     "remark-preset-lint-recommended": "^3.0.3",
@@ -100,7 +99,6 @@
     "plugins": [
       "remark-preset-lint-markdown-style-guide",
       "remark-preset-lint-recommended",
-      "remark-lint-first-heading-level",
       "remark-lint-no-tabs",
       [
         "remark-lint-emphasis-marker",

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -41,7 +41,6 @@
     "plugins": [
       "remark-preset-lint-markdown-style-guide",
       "remark-preset-lint-recommended",
-      "remark-lint-first-heading-level",
       "remark-lint-no-tabs",
       ["remark-lint-emphasis-marker", false],
       ["remark-lint-list-item-indent", false],

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -42,7 +42,6 @@
     "plugins": [
       "remark-preset-lint-markdown-style-guide",
       "remark-preset-lint-recommended",
-      "remark-lint-first-heading-level",
       "remark-lint-no-tabs",
       ["remark-lint-emphasis-marker", false],
       ["remark-lint-list-item-indent", false],


### PR DESCRIPTION
The package is not suitable for the minimum rule set.

BREAKING CHANGE: please install it manually to keep same linting rules