### PR TITLE
feat(remark): remove `remark-lint-no-tabs` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7122,15 +7122,6 @@
         "unist-util-visit": "^1.4.0"
       }
     },
-    "remark-lint-no-tabs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-tabs/-/remark-lint-no-tabs-1.0.3.tgz",
-      "integrity": "sha512-GxmG1LLxYoVjKnQ39On4mFEiVwpLfR3BPTXyaC9UCBUj9fnDQ7ANXceeCsPAyxamr0UM4r2tk/hB9mNT4rLskQ==",
-      "requires": {
-        "unified-lint-rule": "^1.0.0",
-        "vfile-location": "^2.0.1"
-      }
-    },
     "remark-lint-no-undefined-references": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "remark-cli": "^6.0.1",
-    "remark-lint-no-tabs": "^1.0.3",
     "remark-preset-lint-markdown-style-guide": "^2.1.3",
     "remark-preset-lint-recommended": "^3.0.3",
     "remark-validate-links": "^8.0.3",
@@ -99,7 +98,6 @@
     "plugins": [
       "remark-preset-lint-markdown-style-guide",
       "remark-preset-lint-recommended",
-      "remark-lint-no-tabs",
       [
         "remark-lint-emphasis-marker",
         false

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -41,7 +41,6 @@
     "plugins": [
       "remark-preset-lint-markdown-style-guide",
       "remark-preset-lint-recommended",
-      "remark-lint-no-tabs",
       ["remark-lint-emphasis-marker", false],
       ["remark-lint-list-item-indent", false],
       ["remark-lint-list-item-spacing", false],

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -42,7 +42,6 @@
     "plugins": [
       "remark-preset-lint-markdown-style-guide",
       "remark-preset-lint-recommended",
-      "remark-lint-no-tabs",
       ["remark-lint-emphasis-marker", false],
       ["remark-lint-list-item-indent", false],
       ["remark-lint-list-item-spacing", false],


### PR DESCRIPTION
The package (rule) can conflict with Prettier.