### PR TITLE
fix(remark): use official short plugin names

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,17 +96,17 @@
   },
   "remarkConfig": {
     "plugins": [
-      "remark-preset-lint-recommended",
-      "remark-lint-no-heading-punctuation",
+      "preset-lint-recommended",
+      "lint-no-heading-punctuation",
       [
-        "remark-lint-list-item-bullet-indent",
+        "lint-list-item-bullet-indent",
         false
       ],
       [
-        "remark-lint-list-item-indent",
+        "lint-list-item-indent",
         false
       ],
-      "remark-validate-links"
+      "validate-links"
     ]
   },
   "commitlint": {

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -39,11 +39,11 @@
   },
   "remarkConfig": {
     "plugins": [
-      "remark-preset-lint-recommended",
-      "remark-lint-no-heading-punctuation",
-      ["remark-lint-list-item-bullet-indent", false],
-      ["remark-lint-list-item-indent", false],
-      "remark-validate-links"
+      "preset-lint-recommended",
+      "lint-no-heading-punctuation",
+      ["lint-list-item-bullet-indent", false],
+      ["lint-list-item-indent", false],
+      "validate-links"
     ]
   },
   "commitlint": {

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -40,11 +40,11 @@
   },
   "remarkConfig": {
     "plugins": [
-      "remark-preset-lint-recommended",
-      "remark-lint-no-heading-punctuation",
-      ["remark-lint-list-item-bullet-indent", false],
-      ["remark-lint-list-item-indent", false],
-      "remark-validate-links"
+      "preset-lint-recommended",
+      "lint-no-heading-punctuation",
+      ["lint-list-item-bullet-indent", false],
+      ["lint-list-item-indent", false],
+      "validate-links"
     ]
   },
   "commitlint": {


### PR DESCRIPTION
The short version is without `remark-` prefix.

For example, see <https://www.npmjs.com/package/remark-preset-lint-recommended#use>.