### PR TITLE
feat(remark): stop auto-fix on pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,10 +73,6 @@
         "eslint --fix --no-ignore",
         "git add"
       ],
-      "*.md": [
-        "remark --output --",
-        "git add"
-      ],
       "*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}": [
         "prettier --write",
         "git add"

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -24,7 +24,6 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx,mjs,ts,tsx}": ["eslint --fix --no-ignore", "git add"],
-      "*.md": ["remark --output --", "git add"],
       "*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}": ["prettier --write", "git add"]
     },
     "ignore": ["CHANGELOG.md"]

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -25,7 +25,6 @@
     "*.css": "xyz",
     "linters": {
       "*.{js,jsx,mjs,ts,tsx}": ["eslint --fix --no-ignore", "git add"],
-      "*.md": ["remark --output --", "git add"],
       "*.{css,html,js,json,jsx,md,mjs,scss,ts,tsx,yaml,yml}": ["prettier --write", "git add"]
     },
     "ignore": ["CHANGELOG.md"]


### PR DESCRIPTION
There is a possibility to conflict with Prettier.

BREAKING CHANGE: please configure manually if you want to fix markdown files on pre-commit