### PR TITLE
feat(deps): update `engines.node` to `>=8.12.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ".remarkignore"
   ],
   "engines": {
-    "node": ">=8.5.0"
+    "node": ">=8.12.0"
   },
   "dependencies": {
     "@commitlint/cli": "^8.0.0",


### PR DESCRIPTION
BREAKING CHANGE: `execa@2.0.2`, which `lint-staged@9` depends on, requires Node 8.12 at minimum

See also sindresorhus/execa#319