### PR TITLE
ci(actions): bump `actions/checkout` from v1 to v2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
         node-version: [10.x, 12.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -8,7 +8,7 @@ jobs:
   npm-audit-fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: ybiquitous/npm-audit-fix-action@implement-action
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/actions/checkout/releases/tag/v2.0.0