### PR TITLE
feat(deps): bump prettier from 1.19.1 to 2.0.4

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -14,7 +14,7 @@ const packagePath = (...pathElements) => path.join(...[__dirname, "..", ...pathE
 const initCommand = (baseDir, logger) => {
   const currentPath = (...pathElems) => path.join(...[baseDir, ...pathElems]);
 
-  const readFile = fileName => read(currentPath(fileName), "utf8");
+  const readFile = (fileName) => read(currentPath(fileName), "utf8");
 
   const copyFile = async (src, dest) => {
     await copy(src, dest);
@@ -43,14 +43,14 @@ const initCommand = (baseDir, logger) => {
       scripts["test:watch"] = `${scripts.test} --watch`;
       scripts["test:coverage"] = 'echo "unsupported." && exit 1';
       Object.keys(originalPackage.scripts)
-        .filter(key => !(key === "test" || key.startsWith("test:")))
-        .forEach(key => {
+        .filter((key) => !(key === "test" || key.startsWith("test:")))
+        .forEach((key) => {
           scripts[key] = originalPackage.scripts[key];
         });
 
       // update other keys
-      const keys = ["husky", "lint-staged", "standard-version", "prettier", "remarkConfig"];
-      keys.forEach(key => {
+      const keys = ["husky", "lint-staged", "standard-version", "remarkConfig"];
+      keys.forEach((key) => {
         if (!(key in packageInfo)) {
           packageInfo[key] = {};
         }
@@ -72,7 +72,7 @@ const initCommand = (baseDir, logger) => {
   };
 };
 
-const defaultLogger = msg => process.stdout.write(`${msg}${EOL}`);
+const defaultLogger = (msg) => process.stdout.write(`${msg}${EOL}`);
 
 module.exports = async function init({ cwd = process.cwd(), logger = defaultLogger } = {}) {
   const cmd = initCommand(cwd, logger);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6125,9 +6125,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w=="
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.1.3",
     "npm-run-all": "^4.1.5",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.4",
     "remark-cli": "^8.0.0",
     "remark-lint-no-heading-punctuation": "^2.0.0",
     "remark-preset-lint-recommended": "^4.0.0",
@@ -53,7 +53,7 @@
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
-    "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mdx,mjs,scss,ts,tsx,yaml,yml}\"",
+    "prettier": "prettier --ignore-path .gitignore .",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
@@ -69,11 +69,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx}": "eslint --fix --no-ignore",
-    "*.{css,html,js,json,jsx,md,mdx,mjs,scss,ts,tsx,yaml,yml}": "prettier --write",
+    "*": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
-  },
-  "prettier": {
-    "trailingComma": "es5"
   },
   "standard-version": {
     "sign": true,

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -8,7 +8,7 @@
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
-    "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mdx,mjs,scss,ts,tsx,yaml,yml}\"",
+    "prettier": "prettier --ignore-path .gitignore .",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx}": "eslint --fix --no-ignore",
-    "*.{css,html,js,json,jsx,md,mdx,mjs,scss,ts,tsx,yaml,yml}": "prettier --write",
+    "*": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },
   "standard-version": {
@@ -32,9 +32,6 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
-  },
-  "prettier": {
-    "trailingComma": "es5"
   },
   "remarkConfig": {
     "plugins": [

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -8,7 +8,7 @@
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
     "lint": "npm-run-all --print-label --parallel lint:*",
-    "prettier": "prettier --ignore-path .gitignore \"**/*.{css,html,js,json,jsx,md,mdx,mjs,scss,ts,tsx,yaml,yml}\"",
+    "prettier": "prettier --ignore-path .gitignore .",
     "prettier:check": "npm run prettier -- --check",
     "prettier:write": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --parallel lint:*:fix prettier:write",
@@ -25,7 +25,7 @@
   "lint-staged": {
     "*.css": "xyz",
     "*.{js,jsx,mjs,ts,tsx}": "eslint --fix --no-ignore",
-    "*.{css,html,js,json,jsx,md,mdx,mjs,scss,ts,tsx,yaml,yml}": "prettier --write",
+    "*": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },
   "standard-version": {
@@ -33,9 +33,6 @@
     "scripts": {
       "postchangelog": "prettier --write CHANGELOG.md"
     }
-  },
-  "prettier": {
-    "trailingComma": "es5"
   },
   "remarkConfig": {
     "plugins": [

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -14,10 +14,10 @@ Options:
   --version, -v  Show version number                                   [boolean]
 `.trim();
 
-test("help", t => {
-  [[], ["unknown"], ["unknown", "xyz"]].forEach(args => {
-    t.test(`with arguments [${args.join(", ")}]`, async t => {
-      const error = await exec(...args).catch(err => err);
+test("help", (t) => {
+  [[], ["unknown"], ["unknown", "xyz"]].forEach((args) => {
+    t.test(`with arguments [${args.join(", ")}]`, async (t) => {
+      const error = await exec(...args).catch((err) => err);
       const { code, stdout, stderr } = error;
       t.ok(error instanceof Error);
       t.is(code, 1);
@@ -26,8 +26,8 @@ test("help", t => {
       t.end();
     });
   });
-  ["--help", "-h"].forEach(option => {
-    t.test(`with "${option}" option`, async t => {
+  ["--help", "-h"].forEach((option) => {
+    t.test(`with "${option}" option`, async (t) => {
       const { stdout, stderr } = await exec(option);
       t.ok(stdout.includes(HELP));
       t.is(stderr, "");

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -6,20 +6,20 @@ const pkg = require("../package.json");
 const init = require("../lib/init");
 const exec = require("./helpers/exec");
 
-const readFile = file => fse.readFile(file, "utf8");
-const readJSON = file => fse.readJSON(file, "utf8");
+const readFile = (file) => fse.readFile(file, "utf8");
+const readJSON = (file) => fse.readJSON(file, "utf8");
 
 const sandbox = async (fn, t) => {
   const workDir = path.join(os.tmpdir(), `${pkg.name}${Date.now()}`);
   await fse.mkdirs(workDir);
 
   const logMsgs = [];
-  const logger = msg => logMsgs.push(msg);
+  const logger = (msg) => logMsgs.push(msg);
 
   try {
     const cwd = process.cwd();
-    const fixturePath = name => path.join(cwd, "test", "fixtures", name);
-    const fixture = async name => {
+    const fixturePath = (name) => path.join(cwd, "test", "fixtures", name);
+    const fixture = async (name) => {
       const src = fixturePath(name);
       const dest = path.join(workDir, "package.json");
       await fse.copy(src, dest);
@@ -29,10 +29,10 @@ const sandbox = async (fn, t) => {
     return await fn(t, {
       fixturePath,
       fixture,
-      readFixture: name => readFile(fixturePath(name)),
-      readFixtureJSON: name => readJSON(fixturePath(name)),
-      readOrigFile: name => readFile(path.join(cwd, name)),
-      readWorkFile: name => readFile(path.join(workDir, name)),
+      readFixture: (name) => readFile(fixturePath(name)),
+      readFixtureJSON: (name) => readJSON(fixturePath(name)),
+      readOrigFile: (name) => readFile(path.join(cwd, name)),
+      readWorkFile: (name) => readFile(path.join(workDir, name)),
       logMessage: () => logMsgs.join(""),
       initArgs: { cwd: workDir, logger },
     });
@@ -41,9 +41,9 @@ const sandbox = async (fn, t) => {
   }
 };
 
-test("init", t => {
+test("init", (t) => {
   const testInSandbox = (name, fn) => {
-    t.test(name, t => sandbox(fn, t));
+    t.test(name, (t) => sandbox(fn, t));
   };
 
   testInSandbox('update "package.json"', async (t, ctx) => {
@@ -64,7 +64,7 @@ test("init", t => {
     t.end();
   });
 
-  [".editorconfig", ".remarkignore"].forEach(file => {
+  [".editorconfig", ".remarkignore"].forEach((file) => {
     testInSandbox(`write "${file}"`, async (t, ctx) => {
       await ctx.fixture("package-normal.json");
       await init(ctx.initArgs);
@@ -80,7 +80,7 @@ test("init", t => {
   });
 
   testInSandbox("throw error if no package.json", async (t, ctx) => {
-    const error = await init(ctx.initArgs).catch(err => err);
+    const error = await init(ctx.initArgs).catch((err) => err);
     t.ok(error instanceof Error);
     t.is(error.code, "ENOENT");
     t.end();

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,8 +1,8 @@
 const test = require("tape");
 const main = require("..");
 
-test("main", t => {
-  t.test("init", t => {
+test("main", (t) => {
+  t.test("init", (t) => {
     const { init } = main;
     t.is(typeof init, "function");
     t.is(init.name, "init");

--- a/test/version.test.js
+++ b/test/version.test.js
@@ -2,9 +2,9 @@ const test = require("tape");
 const pkg = require("../package.json");
 const exec = require("./helpers/exec");
 
-test("version", t => {
-  ["--version", "-v"].forEach(option => {
-    t.test(`with "${option}" option`, async t => {
+test("version", (t) => {
+  ["--version", "-v"].forEach((option) => {
+    t.test(`with "${option}" option`, async (t) => {
       const { stdout, stderr } = await exec(option);
       t.is(stdout.trim(), pkg.version);
       t.is(stderr, "");


### PR DESCRIPTION
See the [Prettier v2 release note](https://prettier.io/blog/2020/03/21/2.0.0.html).

BREAKING CHANGE: Change defaults and use `.` instead of `**.{ext1,ext2}`.