### PR TITLE
test: use `process.hrtime` instead of `Date.now`

### DIFF
--- a/test/init.test.js
+++ b/test/init.test.js
@@ -13,7 +13,7 @@ const readJSON = (file) => fs.promises.readFile(file, "utf8").then(JSON.parse);
 /* eslint-enable node/no-unsupported-features/node-builtins */
 
 const sandbox = async (fn, t) => {
-  const workDir = path.join(os.tmpdir(), `${pkg.name}${Date.now()}`);
+  const workDir = path.join(os.tmpdir(), `${pkg.name}${process.hrtime.bigint()}`);
   await fs.promises.mkdir(workDir); // eslint-disable-line node/no-unsupported-features/node-builtins
 
   const logMsgs = [];


### PR DESCRIPTION
It has a higher precision.
See https://nodejs.org/api/process.html#process_process_hrtime_bigint