### PR TITLE
feat(eslint): simplify config since v7

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -60,6 +60,7 @@ const initCommand = (baseDir, logger) => {
         extends: ["@commitlint/config-conventional"],
       };
       packageInfo.eslintConfig = {
+        root: true,
         extends: ["ybiquitous"],
       };
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "nyc --check-coverage --lines 100 --branches 90 tape \"test/**/*.test.js\"",
     "test:watch": "nodemon --ext js,json --watch . --exec \"tape test/**/*.test.js\"",
     "test:coverage": "nyc report --reporter=html",
-    "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs,.ts,.tsx .",
+    "lint:js": "eslint .",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
@@ -68,7 +68,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --fix --no-ignore",
+    "*.{js,jsx,mjs,ts,tsx}": "eslint --fix",
     "*": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },
@@ -125,6 +125,7 @@
     }
   },
   "eslintConfig": {
+    "root": true,
     "extends": [
       "ybiquitous/node"
     ],

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -3,7 +3,7 @@
     "test": "test",
     "test:watch": "test --watch",
     "test:coverage": "echo \"unsupported.\" && exit 1",
-    "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs,.ts,.tsx .",
+    "lint:js": "eslint .",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:md": "remark . --frail",
     "lint:md:fix": "remark . --output",
@@ -23,7 +23,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --fix --no-ignore",
+    "*.{js,jsx,mjs,ts,tsx}": "eslint --fix",
     "*": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },
@@ -46,6 +46,7 @@
     "extends": ["@commitlint/config-conventional"]
   },
   "eslintConfig": {
+    "root": true,
     "extends": ["ybiquitous"]
   }
 }

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "test": "abc",
-    "lint:js": "eslint --ignore-path .gitignore --ext .js,.jsx,.mjs,.ts,.tsx .",
+    "lint:js": "eslint .",
     "test:watch": "abc --watch",
     "test:coverage": "echo \"unsupported.\" && exit 1",
     "lint:js:fix": "npm run lint:js -- --fix",
@@ -24,7 +24,7 @@
   },
   "lint-staged": {
     "*.css": "xyz",
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --fix --no-ignore",
+    "*.{js,jsx,mjs,ts,tsx}": "eslint --fix",
     "*": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },
@@ -47,6 +47,7 @@
     "extends": ["@commitlint/config-conventional"]
   },
   "eslintConfig": {
+    "root": true,
     "extends": ["ybiquitous"]
   }
 }


### PR DESCRIPTION
- Set `root: true`.
- Remove `--ignore-path`.
- Remove `--no-ignore`.
- Remove `--ext`

See also https://eslint.org/blog/2020/05/eslint-v7.0.0-released

Related to #639 