### PR TITLE
feat(commitlint): loosen `body-max-line-length` rule

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -60,6 +60,9 @@ const initCommand = (baseDir, logger) => {
       });
       packageInfo.commitlint = {
         extends: ["@commitlint/config-conventional"],
+        rules: {
+          "body-max-line-length": [1, "always", 100],
+        },
       };
       packageInfo.eslintConfig = {
         root: true,

--- a/package.json
+++ b/package.json
@@ -102,6 +102,11 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
+      "body-max-line-length": [
+        1,
+        "always",
+        100
+      ],
       "scope-enum": [
         2,
         "always",

--- a/test/fixtures/package-empty_expected.json
+++ b/test/fixtures/package-empty_expected.json
@@ -43,7 +43,10 @@
     ]
   },
   "commitlint": {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": ["@commitlint/config-conventional"],
+    "rules": {
+      "body-max-line-length": [1, "always", 100]
+    }
   },
   "eslintConfig": {
     "root": true,

--- a/test/fixtures/package-normal_expected.json
+++ b/test/fixtures/package-normal_expected.json
@@ -44,7 +44,10 @@
     ]
   },
   "commitlint": {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": ["@commitlint/config-conventional"],
+    "rules": {
+      "body-max-line-length": [1, "always", 100]
+    }
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
`@commitlint/config-conventional` has `body-max-line-length: [2, always, 100]`,
but this setting is too strict to me.