### PR TITLE
feat(commitlint): loosen `body-max-line-length` rule again

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,9 +103,9 @@
     ],
     "rules": {
       "body-max-line-length": [
-        1,
+        2,
         "always",
-        100
+        200
       ],
       "scope-enum": [
         2,


### PR DESCRIPTION
`level: 1` fails on `wagoid/commitlint-github-action`, so this change increases the length value.

See also #649