### PR TITLE
feat(init): exclude snapshot files from Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,mjs,ts,tsx}": "eslint --fix",
-    "*": "prettier --write",
+    "!(*.snap)": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },
   "standard-version": {

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -28,8 +28,8 @@ Object {
     },
   },
   "lint-staged": Object {
+    "!(*.snap)": "prettier --write",
     "!(CHANGELOG).md": "remark --frail",
-    "*": "prettier --write",
     "*.css": "xyz",
     "*.{js,jsx,mjs,ts,tsx}": "eslint --fix",
   },
@@ -103,8 +103,8 @@ Object {
     },
   },
   "lint-staged": Object {
+    "!(*.snap)": "prettier --write",
     "!(CHANGELOG).md": "remark --frail",
-    "*": "prettier --write",
     "*.{js,jsx,mjs,ts,tsx}": "eslint --fix",
   },
   "remarkConfig": Object {


### PR DESCRIPTION
`*.snap` files for Jest. See <https://jestjs.io/docs/en/snapshot-testing>