### PR TITLE
chore(deps): set `versioning-strategy` default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
       time: "20:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 10
-    versioning-strategy: increase
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot sets a suitable value by default:

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#versioning-strategy