### PR TITLE
fix(init): support husky v5 migration

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -99,6 +99,7 @@ const initCommand = (baseDir, logger) => {
         extends: ["ybiquitous"],
       };
 
+      // Delete husky v4 configuration.
       delete packageInfo.husky;
 
       await writeFile("package.json", JSON.stringify(packageInfo, null, 2));

--- a/lib/init.js
+++ b/lib/init.js
@@ -99,6 +99,8 @@ const initCommand = (baseDir, logger) => {
         extends: ["ybiquitous"],
       };
 
+      delete packageInfo.husky;
+
       await writeFile("package.json", JSON.stringify(packageInfo, null, 2));
     },
 
@@ -113,6 +115,7 @@ const initCommand = (baseDir, logger) => {
 };
 
 /** @type {import("../types/ybiq").InitCommand} */
+// eslint-disable-next-line max-statements
 async function init({ cwd = process.cwd(), logger = defaultLogger } = {}) {
   const cmd = initCommand(cwd, logger);
 
@@ -123,6 +126,9 @@ async function init({ cwd = process.cwd(), logger = defaultLogger } = {}) {
   await cmd.writePackageFile(".github", "workflows", "npm-audit-fix.yml");
   await cmd.writePackageFile(".github", "workflows", "release.yml");
   await cmd.writePackageFile(".github", "workflows", "test.yml");
+  await cmd.writePackageFile(".husky", "commit-msg");
+  await cmd.writePackageFile(".husky", "post-commit");
+  await cmd.writePackageFile(".husky", "pre-commit");
 }
 module.exports.init = init;
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     ".github/workflows/commitlint.yml",
     ".github/workflows/npm-audit-fix.yml",
     ".github/workflows/release.yml",
-    ".github/workflows/test.yml"
+    ".github/workflows/test.yml",
+    ".husky/commit-msg",
+    ".husky/post-commit",
+    ".husky/pre-commit"
   ],
   "engines": {
     "node": ">=12.13.0"

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -259,6 +259,30 @@ jobs:
 "
 `;
 
+exports[`write ".husky/commit-msg" 1`] = `
+"#!/bin/sh
+. \\"$(dirname \\"$0\\")/_/husky.sh\\"
+
+npx --no-install commitlint --edit \\"$1\\"
+"
+`;
+
+exports[`write ".husky/post-commit" 1`] = `
+"#!/bin/sh
+. \\"$(dirname \\"$0\\")/_/husky.sh\\"
+
+npm run release:dry-run
+"
+`;
+
+exports[`write ".husky/pre-commit" 1`] = `
+"#!/bin/sh
+. \\"$(dirname \\"$0\\")/_/husky.sh\\"
+
+npx --no-install lint-staged
+"
+`;
+
 exports[`write ".remarkignore" 1`] = `
 "CHANGELOG.md
 "

--- a/test/fixtures/package-normal.json
+++ b/test/fixtures/package-normal.json
@@ -11,5 +11,8 @@
   },
   "eslintConfig": {
     "extends": []
+  },
+  "husky": {
+    "hooks": {}
   }
 }

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -57,6 +57,9 @@ test('update "package.json" without fields', () =>
   ".github/workflows/npm-audit-fix.yml",
   ".github/workflows/release.yml",
   ".github/workflows/test.yml",
+  ".husky/commit-msg",
+  ".husky/post-commit",
+  ".husky/pre-commit",
 ].forEach((file) => {
   test(`write "${file}"`, () =>
     sandbox(async (ctx) => {
@@ -90,6 +93,9 @@ test("End-to-End via CLI", () =>
       => \`.github/workflows/npm-audit-fix.yml\` was updated
       => \`.github/workflows/release.yml\` was updated
       => \`.github/workflows/test.yml\` was updated
+      => \`.husky/commit-msg\` was updated
+      => \`.husky/post-commit\` was updated
+      => \`.husky/pre-commit\` was updated
       "
     `);
     expect(stderr).toEqual("");


### PR DESCRIPTION
- Delete the `husky` field in `package.json` if exists.
- Copy `.husky/*` hook files.
