### PR TITLE
feat(init): improve `test:coverage` script

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -66,7 +66,7 @@ const initCommand = (baseDir, logger) => {
         scripts.test = "test";
       }
       scripts["test:watch"] = `${scripts.test} --watch`;
-      scripts["test:coverage"] = 'echo "unsupported." && exit 1';
+      scripts["test:coverage"] = `${scripts.test} --coverage`;
       Object.keys(originalPackage.scripts)
         .filter((key) => !(key === "test" || key.startsWith("test:")))
         .forEach((key) => {

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -59,7 +59,7 @@ Object {
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
     "test": "abc",
-    "test:coverage": "echo \\"unsupported.\\" && exit 1",
+    "test:coverage": "abc --coverage",
     "test:watch": "abc --watch",
   },
   "standard-version": Object {
@@ -129,7 +129,7 @@ Object {
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
     "test": "test",
-    "test:coverage": "echo \\"unsupported.\\" && exit 1",
+    "test:coverage": "test --coverage",
     "test:watch": "test --watch",
   },
   "standard-version": Object {


### PR DESCRIPTION
For example, Jest supports the `--coverage` flag.