### PR TITLE
ci(actions): use `ybiquitous/npm-diff-action@v1` instead of `main`

### DIFF
--- a/.github/workflows/npm-diff.yml
+++ b/.github/workflows/npm-diff.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ybiquitous/npm-diff-action@main
+      - uses: ybiquitous/npm-diff-action@v1


### PR DESCRIPTION
`v1` is now available:
<https://github.com/ybiquitous/npm-diff-action/releases/tag/v1>