### PR TITLE
fix: replace `main` with `exports` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
           ]
         },
         "rules": {
+          "import/no-internal-modules": "off",
           "node/no-unsupported-features/es-syntax": "off"
         }
       },

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "tool"
   ],
   "type": "module",
-  "main": "lib/index.js",
-  "bin": "lib/cli.js",
-  "types": "types/ybiq.d.ts",
+  "exports": "./lib/index.js",
+  "bin": "./lib/cli.js",
+  "types": "./types/ybiq.d.ts",
   "files": [
     "lib",
     "types",

--- a/test/__snapshots__/help.test.js.snap
+++ b/test/__snapshots__/help.test.js.snap
@@ -25,7 +25,7 @@ Options:
 `;
 
 exports[`with arguments [] 1`] = `
-"Command failed: lib/cli.js
+"Command failed: ./lib/cli.js
 cli.js <command>
 
 Commands:
@@ -40,7 +40,7 @@ Not enough non-option arguments: got 0, need at least 1
 `;
 
 exports[`with arguments []: stderr 1`] = `
-[Error: Command failed: lib/cli.js
+[Error: Command failed: ./lib/cli.js
 cli.js <command>
 
 Commands:
@@ -55,7 +55,7 @@ Not enough non-option arguments: got 0, need at least 1
 `;
 
 exports[`with arguments [unknown, xyz] 1`] = `
-"Command failed: lib/cli.js unknown xyz
+"Command failed: ./lib/cli.js unknown xyz
 cli.js <command>
 
 Commands:
@@ -70,7 +70,7 @@ Unknown arguments: unknown, xyz
 `;
 
 exports[`with arguments [unknown, xyz]: stderr 1`] = `
-[Error: Command failed: lib/cli.js unknown xyz
+[Error: Command failed: ./lib/cli.js unknown xyz
 cli.js <command>
 
 Commands:
@@ -85,7 +85,7 @@ Unknown arguments: unknown, xyz
 `;
 
 exports[`with arguments [unknown] 1`] = `
-"Command failed: lib/cli.js unknown
+"Command failed: ./lib/cli.js unknown
 cli.js <command>
 
 Commands:
@@ -100,7 +100,7 @@ Unknown argument: unknown
 `;
 
 exports[`with arguments [unknown]: stderr 1`] = `
-[Error: Command failed: lib/cli.js unknown
+[Error: Command failed: ./lib/cli.js unknown
 cli.js <command>
 
 Commands:

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,4 +1,4 @@
-import { init } from "..";
+import { init } from "../lib/index.js";
 
 test("init", () => {
   expect(typeof init).toEqual("function");

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,4 +1,5 @@
-import * as ybiq from "../lib/index.js";
+// eslint-disable-next-line import/no-unresolved, node/no-missing-import -- Prevent error: TS7016: Could not find a declaration file for module '../lib/index.js'
+import * as ybiq from "..";
 
 const noop = (arg?: unknown): void => {
   process.stdout.write(String(arg));

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,4 +1,4 @@
-import * as ybiq from "..";
+import * as ybiq from "../lib/index.js";
 
 const noop = (arg?: unknown): void => {
   process.stdout.write(String(arg));


### PR DESCRIPTION
See also:
- [Pure ESM package](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)
- [`"exports"`](https://nodejs.org/api/packages.html#packages_exports)