### PR TITLE
feat(eslint): support `.cjs` extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix",
+    "*.{js,jsx,cjs,mjs,ts,tsx}": "eslint --cache --fix",
     "!(*.snap)": "prettier --write",
     "!(CHANGELOG).md": "remark --frail"
   },

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -30,7 +30,7 @@ Object {
     "!(*.snap)": "prettier --write",
     "!(CHANGELOG).md": "remark --frail",
     "*.css": "xyz",
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix",
+    "*.{js,jsx,cjs,mjs,ts,tsx}": "eslint --cache --fix",
   },
   "remarkConfig": Object {
     "plugins": Array [
@@ -96,7 +96,7 @@ Object {
   "lint-staged": Object {
     "!(*.snap)": "prettier --write",
     "!(CHANGELOG).md": "remark --frail",
-    "*.{js,jsx,mjs,ts,tsx}": "eslint --cache --fix",
+    "*.{js,jsx,cjs,mjs,ts,tsx}": "eslint --cache --fix",
   },
   "remarkConfig": Object {
     "plugins": Array [


### PR DESCRIPTION
The `.cjs` extension is for CommonJS modules. See <https://nodejs.org/api/esm.html>.