### PR TITLE
feat(deps): require Node.js 14.17.0 as a minimum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^4.6.4"
       },
       "engines": {
-        "node": "^14.14.0 || >=16.0.0"
+        "node": "^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ".husky/pre-commit"
   ],
   "engines": {
-    "node": "^14.14.0 || >=16.0.0"
+    "node": "^14.17.0 || >=16.0.0"
   },
   "dependencies": {
     "@commitlint/cli": "^16.2.4",


### PR DESCRIPTION
```console
$ npm ci
npm does not support Node.js v14.14.0
You should probably upgrade to a newer version of node as we
can't make any promises that npm will work with this version.
You can find the latest version at https://nodejs.org/
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: @eslint/eslintrc@1.2.3
npm ERR! notsup Not compatible with your version of node/npm: @eslint/eslintrc@1.2.3
npm ERR! notsup Required: {"node":"^12.22.0 || ^14.17.0 || >=16.0.0"}
npm ERR! notsup Actual:   {"npm":"8.9.0","node":"v14.14.0"}
```

https://nodejs.org/en/blog/release/v14.17.0/