### PR TITLE
feat(init): better `test:*` sub commands

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -78,12 +78,11 @@ const initCommand = (baseDir, logger) => {
       if (!("test" in scripts)) {
         scripts.test = "test";
       }
-      scripts["test:watch"] = `${scripts.test} --watch`;
-      scripts["test:coverage"] = `${scripts.test} --coverage`;
+      scripts["test:watch"] = "npm --ignore-scripts test -- --watch";
+      scripts["test:coverage"] = "npm --ignore-scripts test -- --coverage";
 
       const originalPackage = JSON.parse(
-        // @ts-expect-error
-        await readFile(new URL("../package.json", import.meta.url))
+        await readFile(new URL("../package.json", import.meta.url), "utf-8")
       );
 
       for (const [key, script] of Object.entries(originalPackage.scripts)) {

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage && npm run test:types",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
-    "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
+    "test": "npm run test:types && NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "npm --ignore-scripts test -- --watch",
+    "test:coverage": "npm --ignore-scripts test -- --coverage",
     "test:types": "tsc --project test/tsconfig.test.json --noEmit",
     "lint:js": "eslint --cache --ext=js,jsx,cjs,mjs,ts,tsx .",
     "lint:js:fix": "npm run lint:js -- --fix",

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -57,8 +57,8 @@ exports[`update "package.json" 1`] = `
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
     "test": "abc",
-    "test:coverage": "abc --coverage",
-    "test:watch": "abc --watch",
+    "test:coverage": "npm --ignore-scripts test -- --coverage",
+    "test:watch": "npm --ignore-scripts test -- --watch",
   },
   "standard-version": {
     "scripts": {
@@ -125,8 +125,8 @@ exports[`update "package.json" without fields 1`] = `
     "release": "standard-version",
     "release:dry-run": "standard-version --dry-run",
     "test": "test",
-    "test:coverage": "test --coverage",
-    "test:watch": "test --watch",
+    "test:coverage": "npm --ignore-scripts test -- --coverage",
+    "test:watch": "npm --ignore-scripts test -- --watch",
   },
   "standard-version": {
     "scripts": {


### PR DESCRIPTION
For example, the commit can avoid too long repetition as follows:

```json
{
  "test": "NODE_OPTIONS=--experimental-vm-modules jest --testTimeout 30000",
  "test:watcn": "NODE_OPTIONS=--experimental-vm-modules jest --testTimeout 30000 --watch",
  "test": "NODE_OPTIONS=--experimental-vm-modules jest --testTimeout 30000 --watch"
}
```