### PR TITLE
fix(editorconfig): use `trim_trailing_whitespace` instead of `trim_trailing_spaces`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+# editorconfig.org
 root = true
 
 [*]
@@ -11,4 +12,4 @@ max_line_length = 100
 
 # trailing spaces in markdown indicate word wrap
 [*.md]
-trim_trailing_spaces = false
+trim_trailing_whitespace = false

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -138,7 +138,8 @@ exports[`update "package.json" without fields 1`] = `
 `;
 
 exports[`write ".editorconfig" 1`] = `
-"root = true
+"# editorconfig.org
+root = true
 
 [*]
 end_of_line = lf
@@ -151,7 +152,7 @@ max_line_length = 100
 
 # trailing spaces in markdown indicate word wrap
 [*.md]
-trim_trailing_spaces = false
+trim_trailing_whitespace = false
 "
 `;
 


### PR DESCRIPTION
See <https://github.com/editorconfig/editorconfig/blob/b52217517b2c5b2c3b6a0daa7260983d409e7e6b/.editorconfig>
