### PR TITLE
feat!: remove Node.js 14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["14", "16", "18"]
+        node-version: ["16", "18", "20"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ".husky/pre-commit"
   ],
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "@commitlint/cli": "^17.6.1",

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -226,7 +226,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["14", "16", "18"]
+        node-version: ["16", "18", "20"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: \${{ matrix.node-version }}


### PR DESCRIPTION
Close #1508

BREAKING CHANGE: Node.js 14 support is removed since it's End-of-Life.

This change also adds Node.js 20 to the CI matrix.
