### PR TITLE
refactor: update tsconfig.json to support ES2022

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tsconfig/strictest/tsconfig.json",
   "compilerOptions": {
-    "module": "ES2020",
-    "lib": ["ES2020"]
+    "module": "ES2022",
+    "lib": ["ES2022"]
   },
   "include": ["lib/**/*", "types/**/*"]
 }


### PR DESCRIPTION
`ybiq` will support Node.js 18 or later in the next release. See #1661.
