### PR TITLE
feat(commitlint): loosen `body-max-line-length` from 100 to 300

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -109,7 +109,7 @@ const initCommand = (baseDir, logger) => {
       packageInfo.commitlint = {
         extends: ["@commitlint/config-conventional"],
         rules: {
-          "body-max-line-length": [1, "always", 100],
+          "body-max-line-length": [1, "always", 300],
         },
       };
 

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -10,7 +10,7 @@ exports[`update "package.json" 1`] = `
       "body-max-line-length": [
         1,
         "always",
-        100,
+        300,
       ],
     },
   },
@@ -83,7 +83,7 @@ exports[`update "package.json" without fields 1`] = `
       "body-max-line-length": [
         1,
         "always",
-        100,
+        300,
       ],
     },
   },


### PR DESCRIPTION
100 is sometimes too strict for auto-generated commits like Dependabot pull requests.
