### PR TITLE
feat(husky): replace `npx --no-install` with `npm exec --no`

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no-install commitlint --edit "$1"
+npm exec --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx --no-install lint-staged
+npm exec --no -- lint-staged

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -257,7 +257,7 @@ jobs:
 `;
 
 exports[`write ".husky/commit-msg" 1`] = `
-"npx --no-install commitlint --edit "$1"
+"npm exec --no -- commitlint --edit "$1"
 "
 `;
 
@@ -267,7 +267,7 @@ exports[`write ".husky/post-commit" 1`] = `
 `;
 
 exports[`write ".husky/pre-commit" 1`] = `
-"npx --no-install lint-staged
+"npm exec --no -- lint-staged
 "
 `;
 


### PR DESCRIPTION
> The `--no-install` option is deprecated, and will be converted to `--no`.

-- https://docs.npmjs.com/cli/v9/commands/npm-exec#compatibility-with-older-npx-versions
