### PR TITLE
chore: fix commitlint violation for `header-max-length` rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
         "always",
         300
       ],
+      "header-max-length": [
+        2,
+        "always",
+        120
+      ],
       "scope-enum": [
         2,
         "always",


### PR DESCRIPTION
```
header must not be longer than 100 characters, current length is 106 [header-max-length]
```
