### PR TITLE
fix(actions): explicitly specify permissions to all jobs for security

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   auto-merge:
     uses: ybiquitous/.github/.github/workflows/dependabot-auto-merge-reusable.yml@main
+    permissions:
+      contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,3 +9,6 @@ jobs:
     uses: ybiquitous/.github/.github/workflows/nodejs-release-reusable.yml@main
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}
+    permissions:
+      contents: read
 
   lint:
     uses: ybiquitous/.github/.github/workflows/nodejs-lint-reusable.yml@main
+    permissions:
+      contents: read

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -173,6 +173,8 @@ on:
 jobs:
   auto-merge:
     uses: ybiquitous/.github/.github/workflows/dependabot-auto-merge-reusable.yml@main
+    permissions:
+      contents: write
 "
 `;
 
@@ -229,6 +231,9 @@ jobs:
     uses: ybiquitous/.github/.github/workflows/nodejs-release-reusable.yml@main
     secrets:
       npm-token: \${{ secrets.NPM_TOKEN }}
+    permissions:
+      contents: write
+      id-token: write
 "
 `;
 
@@ -250,9 +255,13 @@ jobs:
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: \${{ matrix.node-version }}
+    permissions:
+      contents: read
 
   lint:
     uses: ybiquitous/.github/.github/workflows/nodejs-lint-reusable.yml@main
+    permissions:
+      contents: read
 "
 `;
 


### PR DESCRIPTION
GitHub recommends specifying `permissions` to mitigate security risks around `GITHUB_TOKEN`.
See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token