### PR TITLE
feat(actions): support npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 jobs:
   release:
     uses: ybiquitous/.github/.github/workflows/nodejs-release-reusable.yml@main
-    secrets:
-      npm-token: ${{ secrets.NPM_TOKEN }}
     permissions:
       contents: write
       id-token: write

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`update "package.json" 1`] = `
 {
@@ -229,8 +229,6 @@ on:
 jobs:
   release:
     uses: ybiquitous/.github/.github/workflows/nodejs-release-reusable.yml@main
-    secrets:
-      npm-token: \${{ secrets.NPM_TOKEN }}
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Secrets will be no longer necessary.

Ref https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
