### PR TITLE
feat(changelog): migrate `standard-version` to `conventional-changelog`

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,1 +1,0 @@
-npm run release:dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# Changelog
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
-
 ## [18.1.0](https://github.com/ybiquitous/ybiq/compare/v18.0.0...v18.1.0) (2025-08-11)
 
 ### Features
@@ -72,7 +68,7 @@ All notable changes to this project will be documented in this file. See [standa
 - **deps:** bump ybiquitous/npm-audit-fix-action from 5 to 6 ([#1673](https://github.com/ybiquitous/ybiq/issues/1673)) ([a7106c6](https://github.com/ybiquitous/ybiq/commit/a7106c6482a6daaa218f5e4420b0214dfa3e0f5a))
 - remove Node.js 16 support ([#1661](https://github.com/ybiquitous/ybiq/issues/1661)) ([cd72806](https://github.com/ybiquitous/ybiq/commit/cd7280624ea1ed1c7d4f18c9e23d178dfed4f711))
 
-### [16.3.1](https://github.com/ybiquitous/ybiq/compare/v16.3.0...v16.3.1) (2023-09-26)
+## [16.3.1](https://github.com/ybiquitous/ybiq/compare/v16.3.0...v16.3.1) (2023-09-26)
 
 ### Bug Fixes
 
@@ -84,7 +80,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 - **deps:** bump actions/checkout from 3 to 4 ([#1609](https://github.com/ybiquitous/ybiq/issues/1609)) ([41600e3](https://github.com/ybiquitous/ybiq/commit/41600e3415e0b8cd8f688487f07785c6b6260725))
 
-### [16.2.1](https://github.com/ybiquitous/ybiq/compare/v16.2.0...v16.2.1) (2023-08-14)
+## [16.2.1](https://github.com/ybiquitous/ybiq/compare/v16.2.0...v16.2.1) (2023-08-14)
 
 ### Bug Fixes
 
@@ -121,19 +117,19 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **deps:** bump ybiquitous/npm-audit-fix-action from 4 to 5 ([#1450](https://github.com/ybiquitous/ybiq/issues/1450)) ([a472f89](https://github.com/ybiquitous/ybiq/commit/a472f89c4bfd104b7c6151fe40ea576e53abf8dc))
 
-### [15.5.3](https://github.com/ybiquitous/ybiq/compare/v15.5.2...v15.5.3) (2023-01-04)
+## [15.5.3](https://github.com/ybiquitous/ybiq/compare/v15.5.2...v15.5.3) (2023-01-04)
 
 ### Bug Fixes
 
 - **actions:** `permissions.contents` for `npm-audit-fix` ([#1449](https://github.com/ybiquitous/ybiq/issues/1449)) ([604619c](https://github.com/ybiquitous/ybiq/commit/604619c2063b421548a10f44f4ea0e5b1804fca0))
 
-### [15.5.2](https://github.com/ybiquitous/ybiq/compare/v15.5.1...v15.5.2) (2022-12-03)
+## [15.5.2](https://github.com/ybiquitous/ybiq/compare/v15.5.1...v15.5.2) (2022-12-03)
 
 ### Bug Fixes
 
 - **actions:** improve "npm diff" workflow ([#1426](https://github.com/ybiquitous/ybiq/issues/1426)) ([2916c73](https://github.com/ybiquitous/ybiq/commit/2916c73cb67d1a2a42bbc9c77942c737cd43bb68))
 
-### [15.5.1](https://github.com/ybiquitous/ybiq/compare/v15.5.0...v15.5.1) (2022-11-29)
+## [15.5.1](https://github.com/ybiquitous/ybiq/compare/v15.5.0...v15.5.1) (2022-11-29)
 
 ### Bug Fixes
 
@@ -146,7 +142,7 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **init:** better `test:*` sub commands ([#1384](https://github.com/ybiquitous/ybiq/issues/1384)) ([dc8ed09](https://github.com/ybiquitous/ybiq/commit/dc8ed09f907eaa64c80966f2dc361c7fc6e4438d))
 
-### [15.4.1](https://github.com/ybiquitous/ybiq/compare/v15.4.0...v15.4.1) (2022-09-08)
+## [15.4.1](https://github.com/ybiquitous/ybiq/compare/v15.4.0...v15.4.1) (2022-09-08)
 
 ### Bug Fixes
 
@@ -159,7 +155,7 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **commitlint:** integrate commitlint and lint ([#1362](https://github.com/ybiquitous/ybiq/issues/1362)) ([47a9596](https://github.com/ybiquitous/ybiq/commit/47a9596bf88521ce20864ecbcd27760264d349cd))
 
-### [15.3.1](https://github.com/ybiquitous/ybiq/compare/v15.3.0...v15.3.1) (2022-09-08)
+## [15.3.1](https://github.com/ybiquitous/ybiq/compare/v15.3.0...v15.3.1) (2022-09-08)
 
 ### Bug Fixes
 
@@ -170,7 +166,6 @@ This change also adds Node.js 20 to the CI matrix.
 ### Features
 
 - **actions:** use reusable release workflow ([#1360](https://github.com/ybiquitous/ybiq/issues/1360)) ([a5661fd](https://github.com/ybiquitous/ybiq/commit/a5661fdeda7c85810846fa39d04ad6938a02640b))
-- **actions:** use reusable workflows ([c114c3b](https://github.com/ybiquitous/ybiq/commit/c114c3b2855228ce47f1023ec2097e27990b54ea))
 - **actions:** use reusable workflows ([#1359](https://github.com/ybiquitous/ybiq/issues/1359)) ([592d238](https://github.com/ybiquitous/ybiq/commit/592d2385266c8f01b0101ee5cf1f18f89836bc46))
 
 ### Bug Fixes
@@ -183,13 +178,13 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **prettier:** add `--cache` option ([#1305](https://github.com/ybiquitous/ybiq/issues/1305)) ([0860daa](https://github.com/ybiquitous/ybiq/commit/0860daa6a1d95a85f21ccec95f7e54007445c8a1))
 
-### [15.1.2](https://github.com/ybiquitous/ybiq/compare/v15.1.1...v15.1.2) (2022-06-20)
+## [15.1.2](https://github.com/ybiquitous/ybiq/compare/v15.1.1...v15.1.2) (2022-06-20)
 
 ### Bug Fixes
 
 - **deps:** bump wagoid/commitlint-github-action from 4 to 5 ([#1301](https://github.com/ybiquitous/ybiq/issues/1301)) ([438f221](https://github.com/ybiquitous/ybiq/commit/438f2214af2e4c87358eca76d257a35330f2aad8))
 
-### [15.1.1](https://github.com/ybiquitous/ybiq/compare/v15.1.0...v15.1.1) (2022-06-13)
+## [15.1.1](https://github.com/ybiquitous/ybiq/compare/v15.1.0...v15.1.1) (2022-06-13)
 
 ### Bug Fixes
 
@@ -244,7 +239,7 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **actions:** bump actions/setup-node from 2 to 3 ([#1195](https://github.com/ybiquitous/ybiq/issues/1195)) ([385e2d5](https://github.com/ybiquitous/ybiq/commit/385e2d5936865a5de5d0edf153f537fa06f3857d))
 
-### [14.0.1](https://github.com/ybiquitous/ybiq/compare/v14.0.0...v14.0.1) (2021-12-29)
+## [14.0.1](https://github.com/ybiquitous/ybiq/compare/v14.0.0...v14.0.1) (2021-12-29)
 
 ### Bug Fixes
 
@@ -281,7 +276,7 @@ This change also adds Node.js 20 to the CI matrix.
 - **deps:** bump lint-staged from 11.2.6 to 12.0.2 ([#1111](https://github.com/ybiquitous/ybiq/issues/1111)) ([b31ffa5](https://github.com/ybiquitous/ybiq/commit/b31ffa5ad84717e31c1e7abf6183f9d2a83db17e))
 - **deps:** bump lint-staged from 12.0.2 to 12.1.1 ([#1117](https://github.com/ybiquitous/ybiq/issues/1117)) ([e926515](https://github.com/ybiquitous/ybiq/commit/e9265151083965f1982d6ecb5cab8aaa532b772b))
 
-### [13.7.1](https://github.com/ybiquitous/ybiq/compare/v13.7.0...v13.7.1) (2021-09-27)
+## [13.7.1](https://github.com/ybiquitous/ybiq/compare/v13.7.0...v13.7.1) (2021-09-27)
 
 ### Bug Fixes
 
@@ -305,7 +300,7 @@ This change also adds Node.js 20 to the CI matrix.
 
 - replace `main` with `exports` in package.json ([#1032](https://github.com/ybiquitous/ybiq/issues/1032)) ([4290ff8](https://github.com/ybiquitous/ybiq/commit/4290ff8df3d2a2c007efe6f66c03579ed848cf77))
 
-### [13.5.1](https://github.com/ybiquitous/ybiq/compare/v13.5.0...v13.5.1) (2021-08-03)
+## [13.5.1](https://github.com/ybiquitous/ybiq/compare/v13.5.0...v13.5.1) (2021-08-03)
 
 ### Bug Fixes
 
@@ -334,7 +329,7 @@ This change also adds Node.js 20 to the CI matrix.
 - **deps:** bump @commitlint/cli from 12.1.4 to 13.1.0 ([#1016](https://github.com/ybiquitous/ybiq/issues/1016)) ([eb740d6](https://github.com/ybiquitous/ybiq/commit/eb740d6effe8e1418163ce7f2411c0f5f181d294))
 - **deps:** bump @commitlint/config-conventional from 12.1.4 to 13.1.0 ([#1013](https://github.com/ybiquitous/ybiq/issues/1013)) ([cefd1ee](https://github.com/ybiquitous/ybiq/commit/cefd1eeda480f8897a23cfab6a8a345b0f9654de))
 
-### [13.2.1](https://github.com/ybiquitous/ybiq/compare/v13.2.0...v13.2.1) (2021-07-19)
+## [13.2.1](https://github.com/ybiquitous/ybiq/compare/v13.2.0...v13.2.1) (2021-07-19)
 
 ### Bug Fixes
 
@@ -345,12 +340,6 @@ This change also adds Node.js 20 to the CI matrix.
 ### Features
 
 - **deps:** bump husky from 6.0.0 to 7.0.0 ([#992](https://github.com/ybiquitous/ybiq/issues/992)) ([3076a00](https://github.com/ybiquitous/ybiq/commit/3076a00f8e9ae9984139a142180b33d3e62e57f4))
-- **init:** add `lint:types:watch` script ([#990](https://github.com/ybiquitous/ybiq/issues/990)) ([4145bb6](https://github.com/ybiquitous/ybiq/commit/4145bb632e44b35d7519f96ef6a1e2010f56caf8))
-
-## [13.2.0](https://github.com/ybiquitous/ybiq/compare/v13.1.0...v13.2.0) (2021-07-02)
-
-### Features
-
 - **init:** add `lint:types:watch` script ([#990](https://github.com/ybiquitous/ybiq/issues/990)) ([4145bb6](https://github.com/ybiquitous/ybiq/commit/4145bb632e44b35d7519f96ef6a1e2010f56caf8))
 
 ## [13.1.0](https://github.com/ybiquitous/ybiq/compare/v13.0.0...v13.1.0) (2021-06-01)
@@ -393,13 +382,13 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **actions:** wrap `cron` with quotes for clarity ([#932](https://github.com/ybiquitous/ybiq/issues/932)) ([1ee02f5](https://github.com/ybiquitous/ybiq/commit/1ee02f543f6f98ff6842997fc54ed0440a61f57c))
 
-### [12.2.2](https://github.com/ybiquitous/ybiq/compare/v12.2.1...v12.2.2) (2021-04-05)
+## [12.2.2](https://github.com/ybiquitous/ybiq/compare/v12.2.1...v12.2.2) (2021-04-05)
 
 ### Bug Fixes
 
 - **deps:** bump ybiquitous/npm-audit-fix-action from v2 to v3 ([#925](https://github.com/ybiquitous/ybiq/issues/925)) ([3101c72](https://github.com/ybiquitous/ybiq/commit/3101c72e2bc3af8ccdbe155680be4c19f8583e97))
 
-### [12.2.1](https://github.com/ybiquitous/ybiq/compare/v12.2.0...v12.2.1) (2021-04-05)
+## [12.2.1](https://github.com/ybiquitous/ybiq/compare/v12.2.0...v12.2.1) (2021-04-05)
 
 ### Bug Fixes
 
@@ -418,25 +407,25 @@ This change also adds Node.js 20 to the CI matrix.
 - **eslint:** enable reportUnusedDisableDirectives ([#914](https://github.com/ybiquitous/ybiq/issues/914)) ([f40e189](https://github.com/ybiquitous/ybiq/commit/f40e1892734e712751be72db18f48c389860965d))
 - **init:** improve test:coverage script ([#915](https://github.com/ybiquitous/ybiq/issues/915)) ([cdfdad9](https://github.com/ybiquitous/ybiq/commit/cdfdad96a9073bb1a91a3dc2d312b8fba65b72da))
 
-### [12.0.4](https://github.com/ybiquitous/ybiq/compare/v12.0.3...v12.0.4) (2021-04-01)
+## [12.0.4](https://github.com/ybiquitous/ybiq/compare/v12.0.3...v12.0.4) (2021-04-01)
 
 ### Bug Fixes
 
 - **actions:** use the latest npm for releasing ([#913](https://github.com/ybiquitous/ybiq/issues/913)) ([bbf440a](https://github.com/ybiquitous/ybiq/commit/bbf440a57af4f0e2ce843b68d640a3d25fab4aba))
 
-### [12.0.3](https://github.com/ybiquitous/ybiq/compare/v12.0.2...v12.0.3) (2021-04-01)
+## [12.0.3](https://github.com/ybiquitous/ybiq/compare/v12.0.2...v12.0.3) (2021-04-01)
 
 ### Bug Fixes
 
 - **deps:** bump husky from 5.2.0 to 6.0.0 ([#909](https://github.com/ybiquitous/ybiq/issues/909)) ([45b1047](https://github.com/ybiquitous/ybiq/commit/45b104715c5a496681609488d201005de42feafc))
 
-### [12.0.2](https://github.com/ybiquitous/ybiq/compare/v12.0.1...v12.0.2) (2021-03-10)
+## [12.0.2](https://github.com/ybiquitous/ybiq/compare/v12.0.1...v12.0.2) (2021-03-10)
 
 ### Bug Fixes
 
 - **actions:** use the latest npm for test ([#896](https://github.com/ybiquitous/ybiq/issues/896)) ([4d874e7](https://github.com/ybiquitous/ybiq/commit/4d874e75566a843d30135e4e8c6ec719f656fbf7))
 
-### [12.0.1](https://github.com/ybiquitous/ybiq/compare/v12.0.0...v12.0.1) (2021-03-10)
+## [12.0.1](https://github.com/ybiquitous/ybiq/compare/v12.0.0...v12.0.1) (2021-03-10)
 
 ### Bug Fixes
 
@@ -456,19 +445,23 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **deps:** bump wagoid/commitlint-github-action from v2 to v3 ([#872](https://github.com/ybiquitous/ybiq/issues/872)) ([c0f6741](https://github.com/ybiquitous/ybiq/commit/c0f674106aae36eb646abada17e478d6941c4f11))
 
+### Reverts
+
+- Revert "chore(release): 12.0.0" ([73f717d](https://github.com/ybiquitous/ybiq/commit/73f717db1c2ab787836de8dfadad64332cec242e))
+
 ## [11.7.0](https://github.com/ybiquitous/ybiq/compare/v11.6.2...v11.7.0) (2021-01-27)
 
 ### Features
 
 - **deps:** require Node.js `>=12.13.0` ([#846](https://github.com/ybiquitous/ybiq/issues/846)) ([227d3ee](https://github.com/ybiquitous/ybiq/commit/227d3ee889eebf4a83ef40e57e612efbdcbaebc3))
 
-### [11.6.2](https://github.com/ybiquitous/ybiq/compare/v11.6.1...v11.6.2) (2021-01-11)
+## [11.6.2](https://github.com/ybiquitous/ybiq/compare/v11.6.1...v11.6.2) (2021-01-11)
 
 ### Bug Fixes
 
 - **deps:** bump actions/setup-node from v2-beta to v2 ([#817](https://github.com/ybiquitous/ybiq/issues/817)) ([61fffc9](https://github.com/ybiquitous/ybiq/commit/61fffc9b4884677a3ba5e024a7ae199515da4b73))
 
-### [11.6.1](https://github.com/ybiquitous/ybiq/compare/v11.6.0...v11.6.1) (2020-10-16)
+## [11.6.1](https://github.com/ybiquitous/ybiq/compare/v11.6.0...v11.6.1) (2020-10-16)
 
 ### Bug Fixes
 
@@ -481,7 +474,7 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **init:** npm publish on GitHub Actions ([#738](https://github.com/ybiquitous/ybiq/issues/738)) ([1da2987](https://github.com/ybiquitous/ybiq/commit/1da2987f07f1d24071b95190004e2d2a5d58f539)), closes [#732](https://github.com/ybiquitous/ybiq/issues/732)
 
-### [11.5.1](https://github.com/ybiquitous/ybiq/compare/v11.5.0...v11.5.1) (2020-10-06)
+## [11.5.1](https://github.com/ybiquitous/ybiq/compare/v11.5.0...v11.5.1) (2020-10-06)
 
 ### Bug Fixes
 
@@ -493,26 +486,26 @@ This change also adds Node.js 20 to the CI matrix.
 
 - **init:** add `clean` and update `prerelease` ([#726](https://github.com/ybiquitous/ybiq/issues/726)) ([286a622](https://github.com/ybiquitous/ybiq/commit/286a62203bc2044665a27de10d3b6b2833a08d7b))
 
-### [11.4.4](https://github.com/ybiquitous/ybiq/compare/v11.4.3...v11.4.4) (2020-09-15)
+## [11.4.4](https://github.com/ybiquitous/ybiq/compare/v11.4.3...v11.4.4) (2020-09-15)
 
 ### Bug Fixes
 
 - **deps:** bump @commitlint/config-conventional from 9.1.2 to 11.0.0 ([#706](https://github.com/ybiquitous/ybiq/issues/706)) ([c31ce18](https://github.com/ybiquitous/ybiq/commit/c31ce18f299b50d324bc0e824336b7dab262ad6f))
 - **deps:** bump yargs from 15.4.1 to 16.0.3 ([#703](https://github.com/ybiquitous/ybiq/issues/703)) ([38a60fb](https://github.com/ybiquitous/ybiq/commit/38a60fb85f2697e7581ce3fe5e9f245dd65ffa8d))
 
-### [11.4.3](https://github.com/ybiquitous/ybiq/compare/v11.4.2...v11.4.3) (2020-08-08)
+## [11.4.3](https://github.com/ybiquitous/ybiq/compare/v11.4.2...v11.4.3) (2020-08-08)
 
 ### Bug Fixes
 
 - **init:** remove needless `on.pull_request.tags` from `test.yml` ([#668](https://github.com/ybiquitous/ybiq/issues/668)) ([8b195dc](https://github.com/ybiquitous/ybiq/commit/8b195dc2e61782f00626b6da4c20ec531c2930ca))
 
-### [11.4.2](https://github.com/ybiquitous/ybiq/compare/v11.4.1...v11.4.2) (2020-08-08)
+## [11.4.2](https://github.com/ybiquitous/ybiq/compare/v11.4.1...v11.4.2) (2020-08-08)
 
 ### Bug Fixes
 
 - **init:** rename `get_version` to `get_tag` ([#667](https://github.com/ybiquitous/ybiq/issues/667)) ([1eddc1c](https://github.com/ybiquitous/ybiq/commit/1eddc1c4b3d5dbdd92eb6c438c07fedeb7fbdcad))
 
-### [11.4.1](https://github.com/ybiquitous/ybiq/compare/v11.4.0...v11.4.1) (2020-08-08)
+## [11.4.1](https://github.com/ybiquitous/ybiq/compare/v11.4.0...v11.4.1) (2020-08-08)
 
 ### Bug Fixes
 
@@ -587,7 +580,7 @@ This change also adds Node.js 20 to the CI matrix.
 
 ### Features
 
-- **standard-version:** add `prerelease` hook ([#480](https://github.com/ybiquitous/ybiq/issues/480)) ([9258362](https://github.com/ybiquitous/ybiq/commit/9258362))
+- **standard-version:** add `prerelease` hook ([#480](https://github.com/ybiquitous/ybiq/issues/480)) ([9258362](https://github.com/ybiquitous/ybiq/commit/9258362815faba40218abaf12fd91506fed800a6))
 
 ## [9.0.0](https://github.com/ybiquitous/ybiq/compare/v8.0.0...v9.0.0) (2019-09-09)
 
@@ -599,402 +592,324 @@ This change also adds Node.js 20 to the CI matrix.
 
 ### Features
 
-- update minimum Node to v10 ([#473](https://github.com/ybiquitous/ybiq/issues/473)) ([6c03057](https://github.com/ybiquitous/ybiq/commit/6c03057))
-- **deps:** bump eslint from 5.16.0 to 6.3.0 ([#476](https://github.com/ybiquitous/ybiq/issues/476)) ([9806de7](https://github.com/ybiquitous/ybiq/commit/9806de7))
-- **deps:** bump husky from 2.7.0 to 3.0.0 ([#438](https://github.com/ybiquitous/ybiq/issues/438)) ([ff6c8bb](https://github.com/ybiquitous/ybiq/commit/ff6c8bb))
-- **deps:** bump lint-staged from 8.2.1 to 9.0.1 ([#439](https://github.com/ybiquitous/ybiq/issues/439)) ([3a0f7d0](https://github.com/ybiquitous/ybiq/commit/3a0f7d0))
-- **deps:** bump remark-cli from 6.0.1 to 7.0.0 ([#453](https://github.com/ybiquitous/ybiq/issues/453)) ([166391e](https://github.com/ybiquitous/ybiq/commit/166391e))
-- **deps:** bump standard-version from 6.0.1 to 7.0.0 ([#456](https://github.com/ybiquitous/ybiq/issues/456)) ([bad2836](https://github.com/ybiquitous/ybiq/commit/bad2836))
-- **deps:** update `engines.node` to `>=8.12.0` ([#441](https://github.com/ybiquitous/ybiq/issues/441)) ([a44dd50](https://github.com/ybiquitous/ybiq/commit/a44dd50)), closes [sindresorhus/execa#319](https://github.com/sindresorhus/execa/issues/319)
-- **lint-staged:** make settings more simple ([#440](https://github.com/ybiquitous/ybiq/issues/440)) ([9660b11](https://github.com/ybiquitous/ybiq/commit/9660b11))
-- **prettier:** support `*.mdx` files ([#433](https://github.com/ybiquitous/ybiq/issues/433)) ([712402f](https://github.com/ybiquitous/ybiq/commit/712402f))
+- **deps:** bump eslint from 5.16.0 to 6.3.0 ([#476](https://github.com/ybiquitous/ybiq/issues/476)) ([9806de7](https://github.com/ybiquitous/ybiq/commit/9806de758763f47d1ee8de3d978c9993e9fc9d6a))
+- **deps:** bump husky from 2.7.0 to 3.0.0 ([#438](https://github.com/ybiquitous/ybiq/issues/438)) ([ff6c8bb](https://github.com/ybiquitous/ybiq/commit/ff6c8bb93c94b61412a89247396d178b8eff49aa))
+- **deps:** bump lint-staged from 8.2.1 to 9.0.1 ([#439](https://github.com/ybiquitous/ybiq/issues/439)) ([3a0f7d0](https://github.com/ybiquitous/ybiq/commit/3a0f7d0e5a281ad95cabea6c47dbf0f833592611))
+- **deps:** bump remark-cli from 6.0.1 to 7.0.0 ([#453](https://github.com/ybiquitous/ybiq/issues/453)) ([166391e](https://github.com/ybiquitous/ybiq/commit/166391e0f794903a09dbfe5ef2902441780fe707))
+- **deps:** bump standard-version from 6.0.1 to 7.0.0 ([#456](https://github.com/ybiquitous/ybiq/issues/456)) ([bad2836](https://github.com/ybiquitous/ybiq/commit/bad2836497fe071e4ff4e6966a5fc40d62766dcd))
+- **deps:** update `engines.node` to `>=8.12.0` ([#441](https://github.com/ybiquitous/ybiq/issues/441)), closes [sindresorhus/execa#319](https://github.com/sindresorhus/execa/issues/319)
+- **lint-staged:** make settings more simple ([#440](https://github.com/ybiquitous/ybiq/issues/440)) ([9660b11](https://github.com/ybiquitous/ybiq/commit/9660b11f8ed156d55b83b10e19ad24a7cc306edf))
+- **prettier:** support `*.mdx` files ([#433](https://github.com/ybiquitous/ybiq/issues/433)) ([712402f](https://github.com/ybiquitous/ybiq/commit/712402f942bed75c17f7bdf5047a1e1c2008c8ae))
+- update minimum Node to v10 ([#473](https://github.com/ybiquitous/ybiq/issues/473)) ([6c03057](https://github.com/ybiquitous/ybiq/commit/6c03057ddb794784a4ea726445817312f7031c9b))
 
 ## [8.0.0](https://github.com/ybiquitous/ybiq/compare/v7.3.0...v8.0.0) (2019-06-24)
 
-### Bug Fixes
-
-- **remark:** missing linting on pre-commit ([#430](https://github.com/ybiquitous/ybiq/issues/430)) ([389aaa6](https://github.com/ybiquitous/ybiq/commit/389aaa6)), closes [#428](https://github.com/ybiquitous/ybiq/issues/428)
-- **remark:** use official short plugin names ([#426](https://github.com/ybiquitous/ybiq/issues/426)) ([a387704](https://github.com/ybiquitous/ybiq/commit/a387704))
-
-### Features
-
-- **deps:** bump standard-version from 5.0.2 to 6.0.1 ([#393](https://github.com/ybiquitous/ybiq/issues/393)) ([7aac359](https://github.com/ybiquitous/ybiq/commit/7aac359))
-- **eslint:** support TypeScript file extensions ([#427](https://github.com/ybiquitous/ybiq/issues/427)) ([5a2bb23](https://github.com/ybiquitous/ybiq/commit/5a2bb23))
-- **remark:** remove `remark-lint-first-heading-level` package ([#423](https://github.com/ybiquitous/ybiq/issues/423)) ([ae09165](https://github.com/ybiquitous/ybiq/commit/ae09165))
-- **remark:** remove `remark-lint-no-tabs` package ([#424](https://github.com/ybiquitous/ybiq/issues/424)) ([30e05ea](https://github.com/ybiquitous/ybiq/commit/30e05ea))
-- **remark:** remove `remark-preset-lint-markdown-style-guide` package ([#425](https://github.com/ybiquitous/ybiq/issues/425)) ([6630938](https://github.com/ybiquitous/ybiq/commit/6630938))
-- **remark:** stop auto-fix on pre-commit ([#428](https://github.com/ybiquitous/ybiq/issues/428)) ([48fbe47](https://github.com/ybiquitous/ybiq/commit/48fbe47))
-
-### Tests
-
-- fix unstable `help` test by locale on localhost ([#390](https://github.com/ybiquitous/ybiq/issues/390)) ([0716e88](https://github.com/ybiquitous/ybiq/commit/0716e88)), closes [/github.com/yargs/yargs/blob/51876e69c71e9861fb09847530eeaec9be534f5f/yargs.js#L1184](https://github.com/ybiquitous/ybiq/issues/L1184) [/github.com/sindresorhus/os-locale/blob/22e9f2e66e1493ffda58c9ed8f936f554bccb76f/index.js#L10](https://github.com/ybiquitous/ybiq/issues/L10)
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - **remark:** please configure manually if you want to fix markdown files on pre-commit
 - **remark:** please install it manually to keep same linting rules
 
-<a name="7.3.0"></a>
+### Features
 
-# [7.3.0](https://github.com/ybiquitous/ybiq/compare/v7.2.2...v7.3.0) (2019-02-15)
+- **deps:** bump standard-version from 5.0.2 to 6.0.1 ([#393](https://github.com/ybiquitous/ybiq/issues/393)) ([7aac359](https://github.com/ybiquitous/ybiq/commit/7aac359fc118d5ee06f87d3cd57788cb163b2c42))
+- **eslint:** support TypeScript file extensions ([#427](https://github.com/ybiquitous/ybiq/issues/427)) ([5a2bb23](https://github.com/ybiquitous/ybiq/commit/5a2bb23677751fcced59490728ad21a39f9ec697))
+- **remark:** remove `remark-lint-first-heading-level` package ([#423](https://github.com/ybiquitous/ybiq/issues/423)) ([ae09165](https://github.com/ybiquitous/ybiq/commit/ae09165298295e27da9ec99a670ea5efc58736c9))
+- **remark:** remove `remark-lint-no-tabs` package ([#424](https://github.com/ybiquitous/ybiq/issues/424)) ([30e05ea](https://github.com/ybiquitous/ybiq/commit/30e05ea557626f5e3783e3c38df4f963d16de2d0))
+- **remark:** remove `remark-preset-lint-markdown-style-guide` package ([#425](https://github.com/ybiquitous/ybiq/issues/425)) ([6630938](https://github.com/ybiquitous/ybiq/commit/66309384f8960264542bc3e92aa5dd9278a2451d))
+- **remark:** stop auto-fix on pre-commit ([#428](https://github.com/ybiquitous/ybiq/issues/428)) ([48fbe47](https://github.com/ybiquitous/ybiq/commit/48fbe47231fe206eb8a9ccef8ed75ae110c2e859))
+
+### Bug Fixes
+
+- **remark:** missing linting on pre-commit ([#430](https://github.com/ybiquitous/ybiq/issues/430)) ([389aaa6](https://github.com/ybiquitous/ybiq/commit/389aaa6bf0edf985c28ac3703607180d6c1f94e7)), closes [#428](https://github.com/ybiquitous/ybiq/issues/428)
+- **remark:** use official short plugin names ([#426](https://github.com/ybiquitous/ybiq/issues/426)) ([a387704](https://github.com/ybiquitous/ybiq/commit/a3877044924e8155f771d2a1060f32daeb01bf09))
+
+## [7.3.0](https://github.com/ybiquitous/ybiq/compare/v7.2.2...v7.3.0) (2019-02-15)
 
 ### Features
 
-- **deps:** bump standard-version from 4.4.0 to 5.0.0 ([#364](https://github.com/ybiquitous/ybiq/issues/364)) ([f125f0a](https://github.com/ybiquitous/ybiq/commit/f125f0a))
-
-<a name="7.2.2"></a>
+- **deps:** bump standard-version from 4.4.0 to 5.0.0 ([#364](https://github.com/ybiquitous/ybiq/issues/364)) ([f125f0a](https://github.com/ybiquitous/ybiq/commit/f125f0a0655c854a484b7de882e09b87ba8addaf))
 
 ## [7.2.2](https://github.com/ybiquitous/ybiq/compare/v7.2.1...v7.2.2) (2019-02-02)
 
 ### Bug Fixes
 
-- **remark:** disable rules conflicting with Prettier ([#349](https://github.com/ybiquitous/ybiq/issues/349)) ([1e45a84](https://github.com/ybiquitous/ybiq/commit/1e45a84))
-
-<a name="7.2.1"></a>
+- **remark:** disable rules conflicting with Prettier ([#349](https://github.com/ybiquitous/ybiq/issues/349)) ([1e45a84](https://github.com/ybiquitous/ybiq/commit/1e45a843468044c0dab2eaa667072ba0a0d27bcf))
 
 ## [7.2.1](https://github.com/ybiquitous/ybiq/compare/v7.2.0...v7.2.1) (2019-02-02)
 
 ### Bug Fixes
 
-- **remark:** fix settings & scripts ([#346](https://github.com/ybiquitous/ybiq/issues/346)) ([f31a097](https://github.com/ybiquitous/ybiq/commit/f31a097))
+- **remark:** fix settings & scripts ([#346](https://github.com/ybiquitous/ybiq/issues/346)) ([f31a097](https://github.com/ybiquitous/ybiq/commit/f31a09728cc284fa8d1468419406e168233d649a))
 
-<a name="7.2.0"></a>
+## [7.2.0](https://github.com/ybiquitous/ybiq/compare/v7.1.0...v7.2.0) (2019-02-02)
 
-# [7.2.0](https://github.com/ybiquitous/ybiq/compare/v7.1.0...v7.2.0) (2019-02-02)
+### Features
+
+- **prettier:** support TypeScript extensions ([#345](https://github.com/ybiquitous/ybiq/issues/345)) ([208a988](https://github.com/ybiquitous/ybiq/commit/208a9880fe5f5272cd1d2426b4c8cb4eb895a259))
 
 ### Bug Fixes
 
-- **standard-version:** revert "simplify settings" ([#343](https://github.com/ybiquitous/ybiq/issues/343)) ([0356fc0](https://github.com/ybiquitous/ybiq/commit/0356fc0))
+- **standard-version:** revert "simplify settings" ([#343](https://github.com/ybiquitous/ybiq/issues/343)) ([0356fc0](https://github.com/ybiquitous/ybiq/commit/0356fc0504641adddf00664f63c06409866ade15))
+
+## [7.1.0](https://github.com/ybiquitous/ybiq/compare/v7.0.0...v7.1.0) (2019-02-01)
 
 ### Features
 
-- **prettier:** support TypeScript extensions ([#345](https://github.com/ybiquitous/ybiq/issues/345)) ([208a988](https://github.com/ybiquitous/ybiq/commit/208a988))
+- **editorconfig:** increase `max_line_length` ([#335](https://github.com/ybiquitous/ybiq/issues/335)) ([df7e35f](https://github.com/ybiquitous/ybiq/commit/df7e35f7d89989c9658ec2ab48bb2a980215cc34))
+- **prettier:** add settings to `package.json` ([#337](https://github.com/ybiquitous/ybiq/issues/337)) ([761c33e](https://github.com/ybiquitous/ybiq/commit/761c33e00020c23b2b1cfb6d2966d9aaa359492d))
+- **remark:** add settings to `package.json` ([#336](https://github.com/ybiquitous/ybiq/issues/336)) ([a536e25](https://github.com/ybiquitous/ybiq/commit/a536e25484a9becd0ba40a7fc1358e51859a4ced))
+- **standard-version:** simplify settings ([#334](https://github.com/ybiquitous/ybiq/issues/334)) ([bd0ff2b](https://github.com/ybiquitous/ybiq/commit/bd0ff2b9e5b18a47908a05ce46cbd4e79840ad5c))
 
-<a name="7.1.0"></a>
+## [7.0.0](https://github.com/ybiquitous/ybiq/compare/v6.0.0...v7.0.0) (2019-01-31)
 
-# [7.1.0](https://github.com/ybiquitous/ybiq/compare/v7.0.0...v7.1.0) (2019-02-01)
-
-### Features
-
-- **editorconfig:** increase `max_line_length` ([#335](https://github.com/ybiquitous/ybiq/issues/335)) ([df7e35f](https://github.com/ybiquitous/ybiq/commit/df7e35f))
-- **prettier:** add settings to `package.json` ([#337](https://github.com/ybiquitous/ybiq/issues/337)) ([761c33e](https://github.com/ybiquitous/ybiq/commit/761c33e))
-- **remark:** add settings to `package.json` ([#336](https://github.com/ybiquitous/ybiq/issues/336)) ([a536e25](https://github.com/ybiquitous/ybiq/commit/a536e25))
-- **standard-version:** simplify settings ([#334](https://github.com/ybiquitous/ybiq/issues/334)) ([bd0ff2b](https://github.com/ybiquitous/ybiq/commit/bd0ff2b))
-
-<a name="7.0.0"></a>
-
-# [7.0.0](https://github.com/ybiquitous/ybiq/compare/v6.0.0...v7.0.0) (2019-01-31)
-
-### Bug Fixes
-
-- **deps:** update `nodemon` for `event-stream` vulnerability ([#296](https://github.com/ybiquitous/ybiq/issues/296)) ([80b2a11](https://github.com/ybiquitous/ybiq/commit/80b2a11))
-- **standard-version:** add `--no-verify` option ([#330](https://github.com/ybiquitous/ybiq/issues/330)) ([b9ecf57](https://github.com/ybiquitous/ybiq/commit/b9ecf57))
-
-### Features
-
-- **init:** drop `fs-extra` from runtime dependencies ([#285](https://github.com/ybiquitous/ybiq/issues/285)) ([2de76eb](https://github.com/ybiquitous/ybiq/commit/2de76eb))
-- **prettier:** add npm scripts ([#321](https://github.com/ybiquitous/ybiq/issues/321)) ([3380443](https://github.com/ybiquitous/ybiq/commit/3380443))
-- **remark:** migrate from `markdownlint` to `remark-lint` ([#326](https://github.com/ybiquitous/ybiq/issues/326)) ([d629afd](https://github.com/ybiquitous/ybiq/commit/d629afd))
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - **remark:** `markdownlint` is unsupported no longer. It may fail linting your Markdown files.
 - **init:** drop support Node 8.4- by using `fs.copyFile()`
 
 http://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback
 
-<a name="6.0.0"></a>
+### Features
 
-# [6.0.0](https://github.com/ybiquitous/ybiq/compare/v5.0.1...v6.0.0) (2018-11-18)
+- **init:** drop `fs-extra` from runtime dependencies ([#285](https://github.com/ybiquitous/ybiq/issues/285)) ([2de76eb](https://github.com/ybiquitous/ybiq/commit/2de76eb8eac86c76eecfe033bb6c943b022c4b24))
+- **prettier:** add npm scripts ([#321](https://github.com/ybiquitous/ybiq/issues/321)) ([3380443](https://github.com/ybiquitous/ybiq/commit/338044333bbe8f5441a95b26f6405d7313260942))
+- **remark:** migrate from `markdownlint` to `remark-lint` ([#326](https://github.com/ybiquitous/ybiq/issues/326)) ([d629afd](https://github.com/ybiquitous/ybiq/commit/d629afd081df5269e15d0c46d5446eb81cd1071c))
 
 ### Bug Fixes
 
-- **deps:** update `husky` from 1.1.3 to 1.1.4 ([#281](https://github.com/ybiquitous/ybiq/issues/281)) ([3f7447a](https://github.com/ybiquitous/ybiq/commit/3f7447a))
-- **deps:** update `lint-staged` from 8.0.4 to 8.0.5 ([#282](https://github.com/ybiquitous/ybiq/issues/282)) ([fe3728f](https://github.com/ybiquitous/ybiq/commit/fe3728f))
-- **deps:** update `yargs` from 12.0.2 to 12.0.4 ([#280](https://github.com/ybiquitous/ybiq/issues/280)) ([3de4120](https://github.com/ybiquitous/ybiq/commit/3de4120))
-- **deps:** update all `dependencies` ([#283](https://github.com/ybiquitous/ybiq/issues/283)) ([60c6703](https://github.com/ybiquitous/ybiq/commit/60c6703))
+- **deps:** update `nodemon` for `event-stream` vulnerability ([#296](https://github.com/ybiquitous/ybiq/issues/296)) ([80b2a11](https://github.com/ybiquitous/ybiq/commit/80b2a116a9fa68420035987b29efb02c485cc134))
+- **standard-version:** add `--no-verify` option ([#330](https://github.com/ybiquitous/ybiq/issues/330)) ([b9ecf57](https://github.com/ybiquitous/ybiq/commit/b9ecf57c4412c27acfde9e58715dcfeac0b71942))
 
-### Features
+## [6.0.0](https://github.com/ybiquitous/ybiq/compare/v5.0.1...v6.0.0) (2018-11-18)
 
-- **commitlint:** move `.commitlintrc.js` to `package.json` ([#277](https://github.com/ybiquitous/ybiq/issues/277)) ([0884342](https://github.com/ybiquitous/ybiq/commit/0884342))
-- **eslint:** move `.eslintrc.js` to `package.json` ([#278](https://github.com/ybiquitous/ybiq/issues/278)) ([5077193](https://github.com/ybiquitous/ybiq/commit/5077193))
-- **prettier:** extend Prettier target files ([#273](https://github.com/ybiquitous/ybiq/issues/273)) ([a89ba5d](https://github.com/ybiquitous/ybiq/commit/a89ba5d))
-- **prettier:** format CHANGELOG.md ([#274](https://github.com/ybiquitous/ybiq/issues/274)) ([be9a697](https://github.com/ybiquitous/ybiq/commit/be9a697))
-- add `npm run format` script ([#279](https://github.com/ybiquitous/ybiq/issues/279)) ([293fbae](https://github.com/ybiquitous/ybiq/commit/293fbae))
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - **eslint:** remove `.eslintrc.js` file
 - **commitlint:** remove `.commitlintrc.js` file
 - **prettier:** remove `.prettierignore` file
 - **prettier:** `lint:md:fix` was replaced with `prettier:write`
 
-<a name="5.0.1"></a>
+### Features
+
+- add `npm run format` script ([#279](https://github.com/ybiquitous/ybiq/issues/279)) ([293fbae](https://github.com/ybiquitous/ybiq/commit/293fbae746b4fadecdd9a391d4d67127c8ac6498))
+- **commitlint:** move `.commitlintrc.js` to `package.json` ([#277](https://github.com/ybiquitous/ybiq/issues/277)) ([0884342](https://github.com/ybiquitous/ybiq/commit/0884342cedc19d621a6b299f71a17e71f87f1a55))
+- **eslint:** move `.eslintrc.js` to `package.json` ([#278](https://github.com/ybiquitous/ybiq/issues/278)) ([5077193](https://github.com/ybiquitous/ybiq/commit/5077193bcec9180af5a1c3b9fa7c4a029e4ed6c3))
+- **prettier:** extend Prettier target files ([#273](https://github.com/ybiquitous/ybiq/issues/273)) ([a89ba5d](https://github.com/ybiquitous/ybiq/commit/a89ba5dee7ece0826421b39988f998d99d63ff3a))
+- **prettier:** format CHANGELOG.md ([#274](https://github.com/ybiquitous/ybiq/issues/274)) ([be9a697](https://github.com/ybiquitous/ybiq/commit/be9a697b380d9f998605df02b29de8297dfea1a3))
+
+### Bug Fixes
+
+- **deps:** update `husky` from 1.1.3 to 1.1.4 ([#281](https://github.com/ybiquitous/ybiq/issues/281)) ([3f7447a](https://github.com/ybiquitous/ybiq/commit/3f7447a39386ef0edae1b8c3907b380453369996))
+- **deps:** update `lint-staged` from 8.0.4 to 8.0.5 ([#282](https://github.com/ybiquitous/ybiq/issues/282)) ([fe3728f](https://github.com/ybiquitous/ybiq/commit/fe3728f472b7c352e14176f44a32269bc378e3d5))
+- **deps:** update `yargs` from 12.0.2 to 12.0.4 ([#280](https://github.com/ybiquitous/ybiq/issues/280)) ([3de4120](https://github.com/ybiquitous/ybiq/commit/3de41202ea5452bc6d8f78fe5a6d32739ef977ad))
+- **deps:** update all `dependencies` ([#283](https://github.com/ybiquitous/ybiq/issues/283)) ([60c6703](https://github.com/ybiquitous/ybiq/commit/60c67036c48f475439ae3148eb6409c21dd96b1c))
 
 ## [5.0.1](https://github.com/ybiquitous/ybiq/compare/v5.0.0...v5.0.1) (2018-11-07)
 
 ### Bug Fixes
 
-- **deps:** update dependency lint-staged to v8 ([#262](https://github.com/ybiquitous/ybiq/issues/262)) ([ea6af96](https://github.com/ybiquitous/ybiq/commit/ea6af96))
+- **deps:** update dependency lint-staged to v8 ([#262](https://github.com/ybiquitous/ybiq/issues/262)) ([ea6af96](https://github.com/ybiquitous/ybiq/commit/ea6af966f9824245a773f653e5c27cf3ac3c7a45))
 
-<a name="5.0.0"></a>
+## [5.0.0](https://github.com/ybiquitous/ybiq/compare/v4.1.0...v5.0.0) (2018-09-26)
 
-# [5.0.0](https://github.com/ybiquitous/ybiq/compare/v4.1.0...v5.0.0) (2018-09-26)
-
-### Bug Fixes
-
-- **deps:** update dependency markdownlint-cli to ^0.13.0 ([#243](https://github.com/ybiquitous/ybiq/issues/243)) ([15b879b](https://github.com/ybiquitous/ybiq/commit/15b879b))
-
-### Features
-
-- **deps:** update dependency husky to v1 ([#253](https://github.com/ybiquitous/ybiq/issues/253)) ([d53ef7c](https://github.com/ybiquitous/ybiq/commit/d53ef7c))
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - **deps:** update husky scripts because husky@1.0.0 has breaking changes
 
-<a name="4.1.0"></a>
+### Features
 
-# [4.1.0](https://github.com/ybiquitous/ybiq/compare/v4.0.0...v4.1.0) (2018-08-11)
+- **deps:** update dependency husky to v1 ([#253](https://github.com/ybiquitous/ybiq/issues/253)) ([d53ef7c](https://github.com/ybiquitous/ybiq/commit/d53ef7c9fb34be1d57cfbacd2673b2dcd099000d))
 
 ### Bug Fixes
 
-- **deps:** update dependency markdownlint-cli to ^0.12.0 ([#232](https://github.com/ybiquitous/ybiq/issues/232)) ([1f3bd43](https://github.com/ybiquitous/ybiq/commit/1f3bd43))
+- **deps:** update dependency markdownlint-cli to ^0.13.0 ([#243](https://github.com/ybiquitous/ybiq/issues/243)) ([15b879b](https://github.com/ybiquitous/ybiq/commit/15b879b0d847f96b25587c9562cb569b7cc3e8d3))
+
+## [4.1.0](https://github.com/ybiquitous/ybiq/compare/v4.0.0...v4.1.0) (2018-08-11)
 
 ### Features
 
-- **markdownlint:** remove "MD030" rule and enable default option ([#238](https://github.com/ybiquitous/ybiq/issues/238)) ([c4ac79c](https://github.com/ybiquitous/ybiq/commit/c4ac79c))
-- **prettier:** add JSON support ([#240](https://github.com/ybiquitous/ybiq/issues/240)) ([c5eb5fa](https://github.com/ybiquitous/ybiq/commit/c5eb5fa))
-- **prettier:** add YAML support ([#239](https://github.com/ybiquitous/ybiq/issues/239)) ([461f7d1](https://github.com/ybiquitous/ybiq/commit/461f7d1))
-
-<a name="4.0.0"></a>
-
-# [4.0.0](https://github.com/ybiquitous/ybiq/compare/v3.4.0...v4.0.0) (2018-07-17)
+- **markdownlint:** remove "MD030" rule and enable default option ([#238](https://github.com/ybiquitous/ybiq/issues/238)) ([c4ac79c](https://github.com/ybiquitous/ybiq/commit/c4ac79cfe126980574b3699536635950894e92dc))
+- **prettier:** add JSON support ([#240](https://github.com/ybiquitous/ybiq/issues/240)) ([c5eb5fa](https://github.com/ybiquitous/ybiq/commit/c5eb5fa0d88bf957733a7aee286a69255e72f4a0))
+- **prettier:** add YAML support ([#239](https://github.com/ybiquitous/ybiq/issues/239)) ([461f7d1](https://github.com/ybiquitous/ybiq/commit/461f7d12899db61e3fd4bef39ae66ed412d9ec0f))
 
 ### Bug Fixes
 
-- **deps:** update dependency fs-extra to v7 ([#227](https://github.com/ybiquitous/ybiq/issues/227)) ([cf738d9](https://github.com/ybiquitous/ybiq/commit/cf738d9))
+- **deps:** update dependency markdownlint-cli to ^0.12.0 ([#232](https://github.com/ybiquitous/ybiq/issues/232)) ([1f3bd43](https://github.com/ybiquitous/ybiq/commit/1f3bd43af461f1d5ea61660a0cd8f1edc44733af))
 
-### Features
+## [4.0.0](https://github.com/ybiquitous/ybiq/compare/v3.4.0...v4.0.0) (2018-07-17)
 
-- **eslint:** remove dependency on `eslint-config-ybiquitous` ([#228](https://github.com/ybiquitous/ybiq/issues/228)) ([ea04df3](https://github.com/ybiquitous/ybiq/commit/ea04df3))
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - **eslint:** remove dependency on `eslint-config-ybiquitous` from `optionalDependencies`
 
-<a name="3.4.0"></a>
+### Features
 
-# [3.4.0](https://github.com/ybiquitous/ybiq/compare/v3.3.3-0...v3.4.0) (2018-07-17)
+- **eslint:** remove dependency on `eslint-config-ybiquitous` ([#228](https://github.com/ybiquitous/ybiq/issues/228)) ([ea04df3](https://github.com/ybiquitous/ybiq/commit/ea04df376da04e57c62805e7da81448b2419bacf))
+
+### Bug Fixes
+
+- **deps:** update dependency fs-extra to v7 ([#227](https://github.com/ybiquitous/ybiq/issues/227)) ([cf738d9](https://github.com/ybiquitous/ybiq/commit/cf738d9e7f4072da09ae36ec8345686ef7ad10c3))
+
+## [3.4.0](https://github.com/ybiquitous/ybiq/compare/v3.3.3-0...v3.4.0) (2018-07-17)
 
 ### Features
 
-- **standard-version:** add `--sign` option ([#226](https://github.com/ybiquitous/ybiq/issues/226)) ([42c4633](https://github.com/ybiquitous/ybiq/commit/42c4633))
-
-<a name="3.3.3-0"></a>
+- **standard-version:** add `--sign` option ([#226](https://github.com/ybiquitous/ybiq/issues/226)) ([42c4633](https://github.com/ybiquitous/ybiq/commit/42c46338bae97957f72ef2927e001db65ea0fdbf))
 
 ## [3.3.3-0](https://github.com/ybiquitous/ybiq/compare/v3.3.2...v3.3.3-0) (2018-07-13)
 
 ### Bug Fixes
 
-- **deps:** update dependency markdownlint-cli to ^0.11.0 ([#223](https://github.com/ybiquitous/ybiq/issues/223)) ([a8d8a8d](https://github.com/ybiquitous/ybiq/commit/a8d8a8d))
-
-<a name="3.3.2"></a>
+- **deps:** update dependency markdownlint-cli to ^0.11.0 ([#223](https://github.com/ybiquitous/ybiq/issues/223)) ([a8d8a8d](https://github.com/ybiquitous/ybiq/commit/a8d8a8d3383d855cafe51619ae80b3ebb0d96965))
 
 ## [3.3.2](https://github.com/ybiquitous/ybiq/compare/v3.3.1...v3.3.2) (2018-07-09)
 
 ### Bug Fixes
 
-- **travis:** deploy failed caused by excluding builds on tags ([5e8a8e8](https://github.com/ybiquitous/ybiq/commit/5e8a8e8))
-
-<a name="3.3.1"></a>
+- **travis:** deploy failed caused by excluding builds on tags ([5e8a8e8](https://github.com/ybiquitous/ybiq/commit/5e8a8e840122fcede5ca8331e0e82272ec387742))
 
 ## [3.3.1](https://github.com/ybiquitous/ybiq/compare/v3.3.0...v3.3.1) (2018-07-09)
 
 ### Bug Fixes
 
-- **init:** trim `--print-name` option from `npm-run-all` ([#218](https://github.com/ybiquitous/ybiq/issues/218)) ([2ceeb86](https://github.com/ybiquitous/ybiq/commit/2ceeb86))
+- **init:** trim `--print-name` option from `npm-run-all` ([#218](https://github.com/ybiquitous/ybiq/issues/218)) ([2ceeb86](https://github.com/ybiquitous/ybiq/commit/2ceeb86fee1a2fddca3db294f7cce2487e21e725))
 
-<a name="3.3.0"></a>
-
-# [3.3.0](https://github.com/ybiquitous/ybiq/compare/v3.2.0...v3.3.0) (2018-06-26)
-
-### Bug Fixes
-
-- **deps:** update dependency yargs to v12 ([cb6a1a1](https://github.com/ybiquitous/ybiq/commit/cb6a1a1))
-- **eslint:** update settings and fix source code ([a236089](https://github.com/ybiquitous/ybiq/commit/a236089))
+## [3.3.0](https://github.com/ybiquitous/ybiq/compare/v3.2.0...v3.3.0) (2018-06-26)
 
 ### Features
 
-- **deps:** bump eslint from 4.19.1 to 5.0.1 ([544aeb6](https://github.com/ybiquitous/ybiq/commit/544aeb6))
-- **deps:** update dependency eslint-config-ybiquitous to v5 ([46e8086](https://github.com/ybiquitous/ybiq/commit/46e8086))
-
-<a name="3.2.0"></a>
-
-# [3.2.0](https://github.com/ybiquitous/ybiq/compare/v3.1.1...v3.2.0) (2018-06-17)
+- **deps:** bump eslint from 4.19.1 to 5.0.1 ([544aeb6](https://github.com/ybiquitous/ybiq/commit/544aeb6072114daadaace338b6387985fe94b874))
+- **deps:** update dependency eslint-config-ybiquitous to v5 ([46e8086](https://github.com/ybiquitous/ybiq/commit/46e808640a56ec9a5546732efc15629b1a806a36))
 
 ### Bug Fixes
 
-- **init:** missing `.markdownlint.json` on published package ([#204](https://github.com/ybiquitous/ybiq/issues/204)) ([54afaeb](https://github.com/ybiquitous/ybiq/commit/54afaeb))
+- **deps:** update dependency yargs to v12 ([cb6a1a1](https://github.com/ybiquitous/ybiq/commit/cb6a1a161b52c068c73c9edaf0eee82ee29424c1))
+- **eslint:** update settings and fix source code ([a236089](https://github.com/ybiquitous/ybiq/commit/a23608963f403bd64c89e60de57be05afafa66d3))
+
+## [3.2.0](https://github.com/ybiquitous/ybiq/compare/v3.1.1...v3.2.0) (2018-06-17)
 
 ### Features
 
-- **init:** add new options (`cwd`, `logger`) to `init()` ([#203](https://github.com/ybiquitous/ybiq/issues/203)) ([7d8b30a](https://github.com/ybiquitous/ybiq/commit/7d8b30a))
+- **init:** add new options (`cwd`, `logger`) to `init()` ([#203](https://github.com/ybiquitous/ybiq/issues/203)) ([7d8b30a](https://github.com/ybiquitous/ybiq/commit/7d8b30a9bb3b4864425e61f9fc7afa810c7e0260))
 
-<a name="3.1.1"></a>
+### Bug Fixes
+
+- **init:** missing `.markdownlint.json` on published package ([#204](https://github.com/ybiquitous/ybiq/issues/204)) ([54afaeb](https://github.com/ybiquitous/ybiq/commit/54afaebf208171a9a0b4056484dcb3b09b82693a))
 
 ## [3.1.1](https://github.com/ybiquitous/ybiq/compare/v3.1.0...v3.1.1) (2018-06-16)
 
 ### Bug Fixes
 
-- **markdownlint:** disable `MD030` rule conflicting with Prettier ([#202](https://github.com/ybiquitous/ybiq/issues/202)) ([7878c5e](https://github.com/ybiquitous/ybiq/commit/7878c5e))
+- **markdownlint:** disable `MD030` rule conflicting with Prettier ([#202](https://github.com/ybiquitous/ybiq/issues/202)) ([7878c5e](https://github.com/ybiquitous/ybiq/commit/7878c5e1afc5fdc0c6948518e032b281b1ea678c))
 
-<a name="3.1.0"></a>
-
-# [3.1.0](https://github.com/ybiquitous/ybiq/compare/v3.0.2...v3.1.0) (2018-06-16)
-
-### Bug Fixes
-
-- **commitlint:** correct `GIT_PARAMS` argument ([#192](https://github.com/ybiquitous/ybiq/issues/192)) ([373f549](https://github.com/ybiquitous/ybiq/commit/373f549))
+## [3.1.0](https://github.com/ybiquitous/ybiq/compare/v3.0.2...v3.1.0) (2018-06-16)
 
 ### Features
 
-- **eslint:** make `eslint-config-ybiquitous` optional ([#194](https://github.com/ybiquitous/ybiq/issues/194)) ([7c0eb9b](https://github.com/ybiquitous/ybiq/commit/7c0eb9b))
-- **init:** improve `lint-staged` settings via `ignore` option ([#196](https://github.com/ybiquitous/ybiq/issues/196)) ([8fe523c](https://github.com/ybiquitous/ybiq/commit/8fe523c))
-- **init:** remove `standard-version` custom settings ([#191](https://github.com/ybiquitous/ybiq/issues/191)) ([d49de38](https://github.com/ybiquitous/ybiq/commit/d49de38))
-- **prettier:** add Markdown support ([#197](https://github.com/ybiquitous/ybiq/issues/197)) ([38d0d9c](https://github.com/ybiquitous/ybiq/commit/38d0d9c))
+- **eslint:** make `eslint-config-ybiquitous` optional ([#194](https://github.com/ybiquitous/ybiq/issues/194)) ([7c0eb9b](https://github.com/ybiquitous/ybiq/commit/7c0eb9bd10e6f070d78aa7439c1438bcc5495923))
+- **init:** improve `lint-staged` settings via `ignore` option ([#196](https://github.com/ybiquitous/ybiq/issues/196)) ([8fe523c](https://github.com/ybiquitous/ybiq/commit/8fe523ccdf0ef6874d9c36e5a2212c4bf112bf1e))
+- **init:** remove `standard-version` custom settings ([#191](https://github.com/ybiquitous/ybiq/issues/191)) ([d49de38](https://github.com/ybiquitous/ybiq/commit/d49de388b6c984c5862b89a47c29e4858e9051b6))
+- **prettier:** add Markdown support ([#197](https://github.com/ybiquitous/ybiq/issues/197)) ([38d0d9c](https://github.com/ybiquitous/ybiq/commit/38d0d9cb9774b72b649cef338db5776fe085dd35))
 
-<a name="3.0.2"></a>
+### Bug Fixes
+
+- **commitlint:** correct `GIT_PARAMS` argument ([#192](https://github.com/ybiquitous/ybiq/issues/192)) ([373f549](https://github.com/ybiquitous/ybiq/commit/373f549bf306b8218978fa2cf44d707e58c1c23f))
 
 ## [3.0.2](https://github.com/ybiquitous/ybiq/compare/v3.0.1...v3.0.2) (2018-06-16)
 
-<a name="3.0.1"></a>
-
 ## [3.0.1](https://github.com/ybiquitous/ybiq/compare/v3.0.0...v3.0.1) (2018-06-08)
 
-<a name="3.0.0"></a>
+## [3.0.0](https://github.com/ybiquitous/ybiq/compare/v2.0.0...v3.0.0) (2018-06-08)
 
-# [3.0.0](https://github.com/ybiquitous/ybiq/compare/v2.0.0...v3.0.0) (2018-06-08)
-
-### Bug Fixes
-
-- **deps:** update commitlint monorepo to v7 ([#181](https://github.com/ybiquitous/ybiq/issues/181)) ([3846081](https://github.com/ybiquitous/ybiq/commit/3846081))
-- **deps:** update dependency fs-extra to v6 ([#157](https://github.com/ybiquitous/ybiq/issues/157)) ([702c498](https://github.com/ybiquitous/ybiq/commit/702c498))
-- **deps:** update dependency markdownlint-cli to ^0.10.0 ([#177](https://github.com/ybiquitous/ybiq/issues/177)) ([54f2cde](https://github.com/ybiquitous/ybiq/commit/54f2cde))
-- **deps:** update dependency markdownlint-cli to ^0.9.0 ([#171](https://github.com/ybiquitous/ybiq/issues/171)) ([76be9dd](https://github.com/ybiquitous/ybiq/commit/76be9dd))
-
-### Features
-
-- drop Node 6 support ([#169](https://github.com/ybiquitous/ybiq/issues/169)) ([4d5364e](https://github.com/ybiquitous/ybiq/commit/4d5364e))
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - Stop supporting Node 6.x which is maintenance LTS.
 
-<a name="2.0.0"></a>
+### Features
 
-# [2.0.0](https://github.com/ybiquitous/ybiq/compare/v1.4.1...v2.0.0) (2018-03-23)
+- drop Node 6 support ([#169](https://github.com/ybiquitous/ybiq/issues/169)) ([4d5364e](https://github.com/ybiquitous/ybiq/commit/4d5364eed5373db2360017223f3a95de96875bf5))
 
 ### Bug Fixes
 
-- **commitlint:** rename config file to `.commitlintrc.js` ([#123](https://github.com/ybiquitous/ybiq/issues/123)) ([8a4aef1](https://github.com/ybiquitous/ybiq/commit/8a4aef1))
-- **deps:** update dependency lint-staged to ^7.0.0 ([#127](https://github.com/ybiquitous/ybiq/issues/127)) ([687c85d](https://github.com/ybiquitous/ybiq/commit/687c85d))
-- **deps:** update dependency markdownlint-cli to ^0.8.0 ([#142](https://github.com/ybiquitous/ybiq/issues/142)) ([6043a26](https://github.com/ybiquitous/ybiq/commit/6043a26))
-- **init:** use `templates/` directory ([#126](https://github.com/ybiquitous/ybiq/issues/126)) ([7e55ab5](https://github.com/ybiquitous/ybiq/commit/7e55ab5))
+- **deps:** update commitlint monorepo to v7 ([#181](https://github.com/ybiquitous/ybiq/issues/181)) ([3846081](https://github.com/ybiquitous/ybiq/commit/3846081ac06586c79c59ec2102652d236e7d97e3))
+- **deps:** update dependency fs-extra to v6 ([#157](https://github.com/ybiquitous/ybiq/issues/157)) ([702c498](https://github.com/ybiquitous/ybiq/commit/702c498c774e00f6b9359d421dd4b90dfadc0939))
+- **deps:** update dependency markdownlint-cli to ^0.10.0 ([#177](https://github.com/ybiquitous/ybiq/issues/177)) ([54f2cde](https://github.com/ybiquitous/ybiq/commit/54f2cde71340b88bdce420ebd6515d3e0c01b578))
+- **deps:** update dependency markdownlint-cli to ^0.9.0 ([#171](https://github.com/ybiquitous/ybiq/issues/171)) ([76be9dd](https://github.com/ybiquitous/ybiq/commit/76be9dd9af46aa898ef7a6dacf8df50c987323dc))
 
-### Features
+## [2.0.0](https://github.com/ybiquitous/ybiq/compare/v1.4.1...v2.0.0) (2018-03-23)
 
-- **init:** migrate from `.commitlintrc.js` to `commitlint.config.js` ([#125](https://github.com/ybiquitous/ybiq/issues/125)) ([d8fc94e](https://github.com/ybiquitous/ybiq/commit/d8fc94e))
-
-### BREAKING CHANGES
+### ⚠ BREAKING CHANGES
 
 - **init:** same as other `*rc.js` files
 
-<a name="1.4.1"></a>
+### Features
+
+- **init:** migrate from `.commitlintrc.js` to `commitlint.config.js` ([#125](https://github.com/ybiquitous/ybiq/issues/125)) ([d8fc94e](https://github.com/ybiquitous/ybiq/commit/d8fc94ec8f642dc799a20ed65299489e772e4055))
+
+### Bug Fixes
+
+- **commitlint:** rename config file to `.commitlintrc.js` ([#123](https://github.com/ybiquitous/ybiq/issues/123)) ([8a4aef1](https://github.com/ybiquitous/ybiq/commit/8a4aef162d211e1c0fa32e3966496d2a751211c1))
+- **deps:** update dependency lint-staged to ^7.0.0 ([#127](https://github.com/ybiquitous/ybiq/issues/127)) ([687c85d](https://github.com/ybiquitous/ybiq/commit/687c85d0a0f52d57ec461690b17557b7102b61d8))
+- **deps:** update dependency markdownlint-cli to ^0.8.0 ([#142](https://github.com/ybiquitous/ybiq/issues/142)) ([6043a26](https://github.com/ybiquitous/ybiq/commit/6043a269c166eff633e180ecf5d51b9d942acf60))
+- **init:** use `templates/` directory ([#126](https://github.com/ybiquitous/ybiq/issues/126)) ([7e55ab5](https://github.com/ybiquitous/ybiq/commit/7e55ab549c64e7153f1e9e7efb11ef1480ac1950))
 
 ## [1.4.1](https://github.com/ybiquitous/ybiq/compare/v1.4.0...v1.4.1) (2018-02-08)
 
 ### Bug Fixes
 
-- **deps:** update dependency markdownlint-cli to ^0.7.1 ([#113](https://github.com/ybiquitous/ybiq/issues/113)) ([85566e6](https://github.com/ybiquitous/ybiq/commit/85566e6))
-- **markdownlint:** ignore CHANGELOG on pre-commit ([#115](https://github.com/ybiquitous/ybiq/issues/115)) ([0b27b2e](https://github.com/ybiquitous/ybiq/commit/0b27b2e))
-- **markdownlint:** stop writing CHANGELOG.md before release ([#111](https://github.com/ybiquitous/ybiq/issues/111)) ([1baf050](https://github.com/ybiquitous/ybiq/commit/1baf050))
+- **deps:** update dependency markdownlint-cli to ^0.7.1 ([#113](https://github.com/ybiquitous/ybiq/issues/113)) ([85566e6](https://github.com/ybiquitous/ybiq/commit/85566e6c35f8f2b4c702ebb5d81e1b81ef18626f))
+- **markdownlint:** ignore CHANGELOG on pre-commit ([#115](https://github.com/ybiquitous/ybiq/issues/115)) ([0b27b2e](https://github.com/ybiquitous/ybiq/commit/0b27b2eeb34d0198d4ee7f0ff0660880720a2551))
+- **markdownlint:** stop writing CHANGELOG.md before release ([#111](https://github.com/ybiquitous/ybiq/issues/111)) ([1baf050](https://github.com/ybiquitous/ybiq/commit/1baf050ba176ef3071c336b26ce3b161315d2101))
 
-<a name="1.4.0"></a>
+## [1.4.0](https://github.com/ybiquitous/ybiq/compare/v1.3.0...v1.4.0) (2018-02-05)
 
-# [1.4.0](https://github.com/ybiquitous/ybiq/compare/v1.3.0...v1.4.0) (2018-02-05)
+### Features
+
+- **markdownlint:** lint files recursively ([#109](https://github.com/ybiquitous/ybiq/issues/109)) ([20a7a1c](https://github.com/ybiquitous/ybiq/commit/20a7a1c0f507cb2bf8652d9648769e0b8dd911cb))
 
 ### Bug Fixes
 
-- **deps:** update dependency markdownlint-cli to ^0.7.0 ([#108](https://github.com/ybiquitous/ybiq/issues/108)) ([0b8a1fe](https://github.com/ybiquitous/ybiq/commit/0b8a1fe))
-- **deps:** update dependency yargs to ^11.0.0 ([#104](https://github.com/ybiquitous/ybiq/issues/104)) ([2aeea90](https://github.com/ybiquitous/ybiq/commit/2aeea90))
+- **deps:** update dependency markdownlint-cli to ^0.7.0 ([#108](https://github.com/ybiquitous/ybiq/issues/108)) ([0b8a1fe](https://github.com/ybiquitous/ybiq/commit/0b8a1fe3e82b6851dca76b5bab7f34ee093ffba6))
+- **deps:** update dependency yargs to ^11.0.0 ([#104](https://github.com/ybiquitous/ybiq/issues/104)) ([2aeea90](https://github.com/ybiquitous/ybiq/commit/2aeea908011ed8f06655d572ad0a85ac63863270))
+
+## [1.3.0](https://github.com/ybiquitous/ybiq/compare/v1.2.0...v1.3.0) (2018-01-19)
 
 ### Features
 
-- **markdownlint:** lint files recursively ([#109](https://github.com/ybiquitous/ybiq/issues/109)) ([20a7a1c](https://github.com/ybiquitous/ybiq/commit/20a7a1c))
+- **package:** update `[@commitlint](https://github.com/commitlint)` packages to 6.0.2 ([#92](https://github.com/ybiquitous/ybiq/issues/92)) ([b5457e5](https://github.com/ybiquitous/ybiq/commit/b5457e5b2dca5b06897c2b6696aff9bdfedae732))
+- **package:** update to Babel 7 (beta) ([#96](https://github.com/ybiquitous/ybiq/issues/96)) ([7a99aa1](https://github.com/ybiquitous/ybiq/commit/7a99aa1d3b943925d8fc9f26e121054420a1fb3f))
 
-<a name="1.3.0"></a>
-
-# [1.3.0](https://github.com/ybiquitous/ybiq/compare/v1.2.0...v1.3.0) (2018-01-19)
+## [1.2.0](https://github.com/ybiquitous/ybiq/compare/v1.1.0...v1.2.0) (2018-01-07)
 
 ### Features
 
-- **package:** update `[@commitlint](https://github.com/commitlint)` packages to 6.0.2 ([#92](https://github.com/ybiquitous/ybiq/issues/92)) ([b5457e5](https://github.com/ybiquitous/ybiq/commit/b5457e5))
-- **package:** update to Babel 7 (beta) ([#96](https://github.com/ybiquitous/ybiq/issues/96)) ([7a99aa1](https://github.com/ybiquitous/ybiq/commit/7a99aa1))
-
-<a name="1.2.0"></a>
-
-# [1.2.0](https://github.com/ybiquitous/ybiq/compare/v1.1.0...v1.2.0) (2018-01-07)
+- **commitlint:** add `@commitlint/travis-cli` ([#88](https://github.com/ybiquitous/ybiq/issues/88)) ([019cd3c](https://github.com/ybiquitous/ybiq/commit/019cd3c7f9d4c215a96d222d2f47b0e9a3f42c08))
+- **commitlint:** add `$GIT_PARAMS` to `commitlint` command ([#78](https://github.com/ybiquitous/ybiq/issues/78)) ([d00784b](https://github.com/ybiquitous/ybiq/commit/d00784b4ef352fd41181395fd4cdf41e56047bdf))
+- **package:** update `eslint-config-ybiquitous` to version 4.2.1 ([#83](https://github.com/ybiquitous/ybiq/issues/83)) ([059a7e1](https://github.com/ybiquitous/ybiq/commit/059a7e1933ab4a21324e0218b5087f5a83c5a3e3))
 
 ### Bug Fixes
 
-- **release:** `release:dry-run` script use `npm run` for DRY ([#79](https://github.com/ybiquitous/ybiq/issues/79)) ([a9546b9](https://github.com/ybiquitous/ybiq/commit/a9546b9))
+- **release:** `release:dry-run` script use `npm run` for DRY ([#79](https://github.com/ybiquitous/ybiq/issues/79)) ([a9546b9](https://github.com/ybiquitous/ybiq/commit/a9546b93c40648a73f317d73d7322b8ac3102121))
+
+## [1.1.0](https://github.com/ybiquitous/ybiq/compare/v1.0.1...v1.1.0) (2017-12-18)
 
 ### Features
 
-- **commitlint:** add `[@commitlint](https://github.com/commitlint)/travis-cli` ([#88](https://github.com/ybiquitous/ybiq/issues/88)) ([019cd3c](https://github.com/ybiquitous/ybiq/commit/019cd3c))
-- **commitlint:** add `$GIT_PARAMS` to `commitlint` command ([#78](https://github.com/ybiquitous/ybiq/issues/78)) ([d00784b](https://github.com/ybiquitous/ybiq/commit/d00784b))
-- **package:** update `eslint-config-ybiquitous` to version 4.2.1 ([#83](https://github.com/ybiquitous/ybiq/issues/83)) ([059a7e1](https://github.com/ybiquitous/ybiq/commit/059a7e1))
-
-<a name="1.1.0"></a>
-
-# [1.1.0](https://github.com/ybiquitous/ybiq/compare/v1.0.1...v1.1.0) (2017-12-18)
-
-### Features
-
-- **editorconfig:** add `max_line_length` ([#65](https://github.com/ybiquitous/ybiq/issues/65)) ([756d7e3](https://github.com/ybiquitous/ybiq/commit/756d7e3))
-- **editorconfig:** disable `trim_trailing_spaces` on markdown files ([#67](https://github.com/ybiquitous/ybiq/issues/67)) ([a0bb6f4](https://github.com/ybiquitous/ybiq/commit/a0bb6f4))
-- **eslint:** add extension `.mjs` for ES modules ([#64](https://github.com/ybiquitous/ybiq/issues/64)) ([2cd62a2](https://github.com/ybiquitous/ybiq/commit/2cd62a2))
-- **package:** update `prettier` to version 1.9.1 ([#72](https://github.com/ybiquitous/ybiq/issues/72)) ([14df958](https://github.com/ybiquitous/ybiq/commit/14df958))
-
-<a name="1.0.1"></a>
+- **editorconfig:** add `max_line_length` ([#65](https://github.com/ybiquitous/ybiq/issues/65)) ([756d7e3](https://github.com/ybiquitous/ybiq/commit/756d7e36fec1a9ca3e70464c32d6bf0ff21a6861))
+- **editorconfig:** disable `trim_trailing_spaces` on markdown files ([#67](https://github.com/ybiquitous/ybiq/issues/67)) ([a0bb6f4](https://github.com/ybiquitous/ybiq/commit/a0bb6f425b0c29ff0c623283e49c220e9c55816e))
+- **eslint:** add extension `.mjs` for ES modules ([#64](https://github.com/ybiquitous/ybiq/issues/64)) ([2cd62a2](https://github.com/ybiquitous/ybiq/commit/2cd62a2a0b14826d6f5b5c96e89bba8b47ceb07f))
+- **package:** update `prettier` to version 1.9.1 ([#72](https://github.com/ybiquitous/ybiq/issues/72)) ([14df958](https://github.com/ybiquitous/ybiq/commit/14df958a92e8b3e34d8d7e10129bc9999fa5dcce))
 
 ## [1.0.1](https://github.com/ybiquitous/ybiq/compare/v1.0.0...v1.0.1) (2017-12-05)
 
 ### Bug Fixes
 
-- **commitlint:** invalid config name (`config-angular`) ([#63](https://github.com/ybiquitous/ybiq/issues/63)) ([dc8b1a5](https://github.com/ybiquitous/ybiq/commit/dc8b1a5))
+- **commitlint:** invalid config name (`config-angular`) ([#63](https://github.com/ybiquitous/ybiq/issues/63)) ([dc8b1a5](https://github.com/ybiquitous/ybiq/commit/dc8b1a57d31a3a15109fd7d963971122e77d015e))
 
-<a name="1.0.0"></a>
+## [1.0.0](https://github.com/ybiquitous/ybiq/compare/v0.6.0...v1.0.0) (2017-12-05)
 
-# [1.0.0](https://github.com/ybiquitous/ybiq/compare/v0.6.0...v1.0.0) (2017-12-05)
+### ⚠ BREAKING CHANGES
 
-### Bug Fixes
-
-- **commitlint:** avoid Angular's new commit convention ([#58](https://github.com/ybiquitous/ybiq/issues/58)) ([97c1f41](https://github.com/ybiquitous/ybiq/commit/97c1f41))
-- **eslint:** simplify `eslint` command options ([#60](https://github.com/ybiquitous/ybiq/issues/60)) ([ef5ec08](https://github.com/ybiquitous/ybiq/commit/ef5ec08))
-- **release:** change commit message format to avoid CommitLint error ([#62](https://github.com/ybiquitous/ybiq/issues/62)) ([5303210](https://github.com/ybiquitous/ybiq/commit/5303210))
-
-### Features
-
-- **package:** update commitlint to version 5.0.1 ([#55](https://github.com/ybiquitous/ybiq/issues/55)) ([df150b5](https://github.com/ybiquitous/ybiq/commit/df150b5))
-- **package:** update eslint to version 4.12.1 ([#57](https://github.com/ybiquitous/ybiq/issues/57)) ([3fa0a4e](https://github.com/ybiquitous/ybiq/commit/3fa0a4e))
-- **package:** update eslint-config-ybiquitous to version 4.0.0 ([#61](https://github.com/ybiquitous/ybiq/issues/61)) ([49bcd40](https://github.com/ybiquitous/ybiq/commit/49bcd40))
-- **package:** update lint-staged to version 6.0.0 ([#56](https://github.com/ybiquitous/ybiq/issues/56)) ([17c8c52](https://github.com/ybiquitous/ybiq/commit/17c8c52))
-
-### BREAKING CHANGES
-
-- **package:** `eslint-config-ybiquitous@4.0.0` uses Prettier, so code style may be changed by auto-fix.
 - **package:** Angular's commit convention has removed the `chore` type. For details, see below links:
 
 * https://github.com/marionebl/commitlint/releases/tag/v5.0.0
@@ -1002,129 +917,120 @@ http://nodejs.org/api/fs.html#fs_fs_copyfile_src_dest_flags_callback
 
 Also add `browserslist` settings to fix lint error.
 
-<a name="0.6.0"></a>
+### Features
 
-# [0.6.0](https://github.com/ybiquitous/ybiq/compare/v0.5.0...v0.6.0) (2017-11-16)
+- **package:** update commitlint to version 5.0.1 ([#55](https://github.com/ybiquitous/ybiq/issues/55)) ([df150b5](https://github.com/ybiquitous/ybiq/commit/df150b558b02787a0707b14cfdd3d2af80bd1e09))
+- **package:** update eslint to version 4.12.1 ([#57](https://github.com/ybiquitous/ybiq/issues/57)) ([3fa0a4e](https://github.com/ybiquitous/ybiq/commit/3fa0a4e7986f8e189bca16b04d10986ed9984107))
+- **package:** update eslint-config-ybiquitous to version 4.0.0 ([#61](https://github.com/ybiquitous/ybiq/issues/61)) ([49bcd40](https://github.com/ybiquitous/ybiq/commit/49bcd404d4687071be8ca7c3928a01ce35b07be1))
+- **package:** update lint-staged to version 6.0.0 ([#56](https://github.com/ybiquitous/ybiq/issues/56)) ([17c8c52](https://github.com/ybiquitous/ybiq/commit/17c8c525c8a48461af1f6582615a26ff0d46451e))
 
 ### Bug Fixes
 
-- show help when unknown command is given ([#52](https://github.com/ybiquitous/ybiq/issues/52)) ([5881bbd](https://github.com/ybiquitous/ybiq/commit/5881bbd))
+- **commitlint:** avoid Angular's new commit convention ([#58](https://github.com/ybiquitous/ybiq/issues/58)) ([97c1f41](https://github.com/ybiquitous/ybiq/commit/97c1f417084a8ee609e5aa1cd513d61c08ab8784))
+- **eslint:** simplify `eslint` command options ([#60](https://github.com/ybiquitous/ybiq/issues/60)) ([ef5ec08](https://github.com/ybiquitous/ybiq/commit/ef5ec08420b61624fd24f91d19f162cd52d1b49a))
+- **release:** change commit message format to avoid CommitLint error ([#62](https://github.com/ybiquitous/ybiq/issues/62)) ([5303210](https://github.com/ybiquitous/ybiq/commit/530321067dcc12b8f3584f1516dd657e6f7e9154))
+
+### Reverts
+
+- Revert "chore(release): change default commit message on release" ([5b812a4](https://github.com/ybiquitous/ybiq/commit/5b812a40f609b759234891ac19e99d8b68a99f34))
+
+## [0.6.0](https://github.com/ybiquitous/ybiq/compare/v0.5.0...v0.6.0) (2017-11-16)
 
 ### Features
 
-- **package:** update lint-staged to version 5.0.0 ([#54](https://github.com/ybiquitous/ybiq/issues/54)) ([4fd9e3e](https://github.com/ybiquitous/ybiq/commit/4fd9e3e))
+- **package:** update lint-staged to version 5.0.0 ([#54](https://github.com/ybiquitous/ybiq/issues/54)) ([4fd9e3e](https://github.com/ybiquitous/ybiq/commit/4fd9e3e5b1ec0a30870350f4a7d262206267937f))
 
-<a name="0.5.0"></a>
+### Bug Fixes
 
-# [0.5.0](https://github.com/ybiquitous/ybiq/compare/v0.4.6...v0.5.0) (2017-10-24)
+- show help when unknown command is given ([#52](https://github.com/ybiquitous/ybiq/issues/52)) ([5881bbd](https://github.com/ybiquitous/ybiq/commit/5881bbd9985f477c4e0430db894c2346d3fbdce2))
+
+## [0.5.0](https://github.com/ybiquitous/ybiq/compare/v0.4.6...v0.5.0) (2017-10-24)
 
 ### Features
 
-- **package:** update yargs to version 10.0.3 ([#43](https://github.com/ybiquitous/ybiq/issues/43)) ([e514983](https://github.com/ybiquitous/ybiq/commit/e514983))
-
-<a name="0.4.6"></a>
+- **package:** update yargs to version 10.0.3 ([#43](https://github.com/ybiquitous/ybiq/issues/43)) ([e514983](https://github.com/ybiquitous/ybiq/commit/e5149832744fa43459ab08b448beeaef97eb6de3))
 
 ## [0.4.6](https://github.com/ybiquitous/ybiq/compare/v0.4.5...v0.4.6) (2017-10-20)
 
 ### Bug Fixes
 
-- **init:** missing `scripts` field in `package.json` ([#39](https://github.com/ybiquitous/ybiq/issues/39)) ([bf3e0cb](https://github.com/ybiquitous/ybiq/commit/bf3e0cb))
-- **init:** output details and exit error code if unexpected error ([#40](https://github.com/ybiquitous/ybiq/issues/40)) ([1f8a042](https://github.com/ybiquitous/ybiq/commit/1f8a042))
-
-<a name="0.4.5"></a>
+- **init:** missing `scripts` field in `package.json` ([#39](https://github.com/ybiquitous/ybiq/issues/39)) ([bf3e0cb](https://github.com/ybiquitous/ybiq/commit/bf3e0cbcb5d372e80c7b26c6fd3db8f54c118e65))
+- **init:** output details and exit error code if unexpected error ([#40](https://github.com/ybiquitous/ybiq/issues/40)) ([1f8a042](https://github.com/ybiquitous/ybiq/commit/1f8a0421cbd43644b5b6dde98e2eb7cf0262015d))
 
 ## [0.4.5](https://github.com/ybiquitous/ybiq/compare/v0.4.4...v0.4.5) (2017-10-19)
-
-<a name="0.4.4"></a>
 
 ## [0.4.4](https://github.com/ybiquitous/ybiq/compare/v0.4.3...v0.4.4) (2017-10-10)
 
 ### Bug Fixes
 
-- **init:** add `standard-version` entry to `package.json` ([#32](https://github.com/ybiquitous/ybiq/issues/32)) ([17a9dc2](https://github.com/ybiquitous/ybiq/commit/17a9dc2))
-
-<a name="0.4.3"></a>
+- **init:** add `standard-version` entry to `package.json` ([#32](https://github.com/ybiquitous/ybiq/issues/32)) ([17a9dc2](https://github.com/ybiquitous/ybiq/commit/17a9dc209c344dd7434e621329fba0b15c6a8490))
 
 ## [0.4.3](https://github.com/ybiquitous/ybiq/compare/v0.4.2...v0.4.3) (2017-10-10)
 
 ### Bug Fixes
 
-- **init:** `yarn lint` outputs more info ([#31](https://github.com/ybiquitous/ybiq/issues/31)) ([79644cf](https://github.com/ybiquitous/ybiq/commit/79644cf))
-
-<a name="0.4.2"></a>
+- **init:** `yarn lint` outputs more info ([#31](https://github.com/ybiquitous/ybiq/issues/31)) ([79644cf](https://github.com/ybiquitous/ybiq/commit/79644cfad6e4c9fcd07e34a685a37a0b301c7bc0))
 
 ## [0.4.2](https://github.com/ybiquitous/ybiq/compare/v0.4.1...v0.4.2) (2017-10-10)
 
 ### Bug Fixes
 
-- add missing `-h` (help) and `-v` (version) aliases ([#30](https://github.com/ybiquitous/ybiq/issues/30)) ([74a70be](https://github.com/ybiquitous/ybiq/commit/74a70be))
-
-<a name="0.4.1"></a>
+- add missing `-h` (help) and `-v` (version) aliases ([#30](https://github.com/ybiquitous/ybiq/issues/30)) ([74a70be](https://github.com/ybiquitous/ybiq/commit/74a70be6e47c084ed4b52487adadd6b9e816c89b))
 
 ## [0.4.1](https://github.com/ybiquitous/ybiq/compare/v0.4.0...v0.4.1) (2017-10-10)
 
 ### Bug Fixes
 
-- **init:** no update `lint:js` command ([#29](https://github.com/ybiquitous/ybiq/issues/29)) ([6f0acc9](https://github.com/ybiquitous/ybiq/commit/6f0acc9))
+- **init:** no update `lint:js` command ([#29](https://github.com/ybiquitous/ybiq/issues/29)) ([6f0acc9](https://github.com/ybiquitous/ybiq/commit/6f0acc93a5563eefd1b7dc4424750835e2620038))
 
-<a name="0.4.0"></a>
-
-# [0.4.0](https://github.com/ybiquitous/ybiq/compare/v0.3.1...v0.4.0) (2017-10-10)
-
-### Bug Fixes
-
-- **init:** make \*.jsx files ESLint's target ([#28](https://github.com/ybiquitous/ybiq/issues/28)) ([8a6899f](https://github.com/ybiquitous/ybiq/commit/8a6899f))
+## [0.4.0](https://github.com/ybiquitous/ybiq/compare/v0.3.1...v0.4.0) (2017-10-10)
 
 ### Features
 
-- **api:** support programmatic API ([#21](https://github.com/ybiquitous/ybiq/issues/21)) ([9c22a80](https://github.com/ybiquitous/ybiq/commit/9c22a80))
-- **init:** add more details to `init` command help ([#27](https://github.com/ybiquitous/ybiq/issues/27)) ([b3c1270](https://github.com/ybiquitous/ybiq/commit/b3c1270))
+- **api:** support programmatic API ([#21](https://github.com/ybiquitous/ybiq/issues/21)) ([9c22a80](https://github.com/ybiquitous/ybiq/commit/9c22a802dbea582d14e9fa77d35b541382eb7b33))
+- **init:** add more details to `init` command help ([#27](https://github.com/ybiquitous/ybiq/issues/27)) ([b3c1270](https://github.com/ybiquitous/ybiq/commit/b3c1270edf0a4380e632cb1fc9aafc915deccc69))
 
-<a name="0.3.1"></a>
+### Bug Fixes
+
+- **init:** make \*.jsx files ESLint's target ([#28](https://github.com/ybiquitous/ybiq/issues/28)) ([8a6899f](https://github.com/ybiquitous/ybiq/commit/8a6899f2e14999ca517105f9f645f173d7606189))
 
 ## [0.3.1](https://github.com/ybiquitous/ybiq/compare/v0.3.0...v0.3.1) (2017-09-25)
 
 ### Bug Fixes
 
-- **init:** add missing files to be published ([#18](https://github.com/ybiquitous/ybiq/issues/18)) ([4d8d108](https://github.com/ybiquitous/ybiq/commit/4d8d108))
+- **init:** add missing files to be published ([#18](https://github.com/ybiquitous/ybiq/issues/18)) ([4d8d108](https://github.com/ybiquitous/ybiq/commit/4d8d108f2b2c27c33c93e1f665df179644d9c7cc))
 
-<a name="0.3.0"></a>
-
-# [0.3.0](https://github.com/ybiquitous/ybiq/compare/v0.2.0...v0.3.0) (2017-09-25)
+## [0.3.0](https://github.com/ybiquitous/ybiq/compare/v0.2.0...v0.3.0) (2017-09-25)
 
 ### Features
 
-- support Node 6 ([#9](https://github.com/ybiquitous/ybiq/issues/9)) ([0085d90](https://github.com/ybiquitous/ybiq/commit/0085d90))
-- use wildcard(\*) for 'npm run lint' ([1e74176](https://github.com/ybiquitous/ybiq/commit/1e74176))
-- **init:** write `commitlint.config.js` ([#15](https://github.com/ybiquitous/ybiq/issues/15)) ([a1266b8](https://github.com/ybiquitous/ybiq/commit/a1266b8))
+- **init:** write `commitlint.config.js` ([#15](https://github.com/ybiquitous/ybiq/issues/15)) ([a1266b8](https://github.com/ybiquitous/ybiq/commit/a1266b8d1e1fa57e78e477af226b295423977fbc))
+- support Node 6 ([#9](https://github.com/ybiquitous/ybiq/issues/9)) ([0085d90](https://github.com/ybiquitous/ybiq/commit/0085d901ed5ecd841302c09043aa43134d620561))
+- use wildcard(\*) for 'npm run lint' ([1e74176](https://github.com/ybiquitous/ybiq/commit/1e74176ecb1f8d6cd0f57a294d0c8b008ccedd7c))
 
 ### Performance Improvements
 
-- prefer not babel code in Node 8+ ([#13](https://github.com/ybiquitous/ybiq/issues/13)) ([cb62636](https://github.com/ybiquitous/ybiq/commit/cb62636))
+- prefer not babel code in Node 8+ ([#13](https://github.com/ybiquitous/ybiq/issues/13)) ([cb62636](https://github.com/ybiquitous/ybiq/commit/cb62636f549740658493c77eaa4ec47e64f05196))
 
-<a name="0.2.0"></a>
-
-# [0.2.0](https://github.com/ybiquitous/ybiq/compare/v0.1.0...v0.2.0) (2017-09-20)
+## [0.2.0](https://github.com/ybiquitous/ybiq/compare/v0.1.0...v0.2.0) (2017-09-24)
 
 ### Features
 
-- add '--version' CLI option ([c87e0f1](https://github.com/ybiquitous/ybiq/commit/c87e0f1))
+- add '--version' CLI option ([8170627](https://github.com/ybiquitous/ybiq/commit/81706278758c42bce58668d0204facf12af3454b))
 
-<a name="0.1.0"></a>
+## [0.1.0](https://github.com/ybiquitous/ybiq/compare/8b6a1501a1eb5d584ab82a775186f2183572432a...v0.1.0) (2017-09-24)
 
-# 0.1.0 (2017-09-20)
+### Features
+
+- add `npm run lint` via `npm-run-all` ([c1ceaff](https://github.com/ybiquitous/ybiq/commit/c1ceaffecf9ff1adadf84959d0e62f2994f51bef))
+- add markdownlint ([edfda2e](https://github.com/ybiquitous/ybiq/commit/edfda2eb67610845d9acc4e4cce1b8347bde1d6d))
+- auto fix `test:watch` script ([d37ba2a](https://github.com/ybiquitous/ybiq/commit/d37ba2add9ca9616bbd3991121d364472cff8b2c))
+- copy `.editorconfig` file on `init` command ([#2](https://github.com/ybiquitous/ybiq/issues/2)) ([81d6870](https://github.com/ybiquitous/ybiq/commit/81d68709a2f284ca83fcead73980853c4361ed5f))
+- implement command-line script ([8b6a150](https://github.com/ybiquitous/ybiq/commit/8b6a1501a1eb5d584ab82a775186f2183572432a))
+- rename project to `ybiq` ([#3](https://github.com/ybiquitous/ybiq/issues/3)) ([72a99ec](https://github.com/ybiquitous/ybiq/commit/72a99ec8ea14e2c770d45aa599358acc6fbba6d4))
+- write `.eslintrc.js` on `init` command ([497b50b](https://github.com/ybiquitous/ybiq/commit/497b50ba8f827eb3bd5cee22b8d690fc1f5dc67b))
 
 ### Bug Fixes
 
-- call `init()` explicitly ([9ad8954](https://github.com/ybiquitous/ybiq/commit/9ad8954))
-- output success message ([01b1dae](https://github.com/ybiquitous/ybiq/commit/01b1dae))
-
-### Features
-
-- add `npm run lint` via `npm-run-all` ([605b722](https://github.com/ybiquitous/ybiq/commit/605b722))
-- add markdownlint ([717a345](https://github.com/ybiquitous/ybiq/commit/717a345))
-- auto fix `test:watch` script ([0bce1f2](https://github.com/ybiquitous/ybiq/commit/0bce1f2))
-- copy `.editorconfig` file on `init` command ([#2](https://github.com/ybiquitous/ybiq/issues/2)) ([c03020c](https://github.com/ybiquitous/ybiq/commit/c03020c))
-- implement command-line script ([8b6a150](https://github.com/ybiquitous/ybiq/commit/8b6a150))
-- rename project to `ybiq` ([#3](https://github.com/ybiquitous/ybiq/issues/3)) ([81899b4](https://github.com/ybiquitous/ybiq/commit/81899b4))
-- write `.eslintrc.js` on `init` command ([e35110d](https://github.com/ybiquitous/ybiq/commit/e35110d))
+- call `init()` explicitly ([9ad8954](https://github.com/ybiquitous/ybiq/commit/9ad8954f96b25313f128ca4f02a5779be8c2f030))
+- output success message ([01b1dae](https://github.com/ybiquitous/ybiq/commit/01b1dae9a1505afc330d92cffd34b51dc2dceb77))

--- a/lib/init.js
+++ b/lib/init.js
@@ -102,7 +102,6 @@ const initCommand = (baseDir, logger) => {
       };
       updateOtherKey("publishConfig");
       updateOtherKey("lint-staged");
-      updateOtherKey("standard-version");
       updateOtherKey("remarkConfig");
 
       // eslint-disable-next-line require-atomic-updates
@@ -135,15 +134,16 @@ const initCommand = (baseDir, logger) => {
       await copy(packagePath(name, ...names), currentPath(name, ...names));
     },
 
-    // NOTE: husky v7 no longer requires `.husky/.gitignore`.
-    //       See https://github.com/typicode/husky/releases/tag/v7.0.0
-    async removeNeedlessHuskyIgnore() {
+    async removeNeedlessFiles() {
+      // NOTE: husky v7 no longer requires `.husky/.gitignore`.
+      //       See https://github.com/typicode/husky/releases/tag/v7.0.0
       await removeForcibly(".husky", ".gitignore");
-    },
 
-    // See https://github.com/ybiquitous/ybiq/pull/1257
-    async removeNeedlessCommitlintWorkflow() {
+      // See https://github.com/ybiquitous/ybiq/pull/1257
       await removeForcibly(".github", "workflows", "commitlint.yml");
+
+      // standard-version is no longer used.
+      await removeForcibly(".husky", "post-commit");
     },
   };
 };
@@ -162,11 +162,9 @@ export async function init({ cwd = process.cwd(), logger = defaultLogger } = {})
   await cmd.writePackageFile(".github", "workflows", "release.yml");
   await cmd.writePackageFile(".github", "workflows", "test.yml");
   await cmd.writePackageFile(".husky", "commit-msg");
-  await cmd.writePackageFile(".husky", "post-commit");
   await cmd.writePackageFile(".husky", "pre-commit");
 
-  await cmd.removeNeedlessHuskyIgnore();
-  await cmd.removeNeedlessCommitlintWorkflow();
+  await cmd.removeNeedlessFiles();
 }
 
 export const command = "init";

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,14 @@
       "dependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "conventional-changelog": "^7.1.1",
+        "conventional-changelog-conventionalcommits": "^9.1.0",
         "eslint": "^8.57.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.6",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.6.2",
         "remark-cli": "^12.0.1",
-        "standard-version": "^9.5.0",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -706,6 +707,18 @@
         "node": ">=v18"
       }
     },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@commitlint/config-validator": {
       "version": "19.8.1",
       "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
@@ -1125,15 +1138,6 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@hutson/parse-repository-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
-      "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2404,6 +2408,67 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@simple-libs/child-process-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-1.0.1.tgz",
+      "integrity": "sha512-3nWd8irxvDI6v856wpPCHZ+08iQR0oHTZfzAZmnbsLzf+Sf1odraP6uKOHDZToXq3RPRV/LbqGVlSCogm9cJjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-libs/stream-utils": "^1.1.0",
+        "@types/node": "^22.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/child-process-utils/node_modules/@types/node": {
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@simple-libs/child-process-utils/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-libs/stream-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-1.1.0.tgz",
+      "integrity": "sha512-6rsHTjodIn/t90lv5snQjRPVtOosM7Vp0AKdrObymq45ojlgVwnpAqdc+0OBBrpEiy31zZ6/TKeIVqV1HwvnuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/dangreen"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils/node_modules/@types/node": {
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@simple-libs/stream-utils/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
@@ -2829,12 +2894,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
-      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
@@ -3449,12 +3508,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/add-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
-      "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
-      "license": "MIT"
-    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -3712,15 +3765,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ast-metadata-inferer": {
@@ -4096,26 +4140,10 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4456,25 +4484,25 @@
       }
     },
     "node_modules/conventional-changelog": {
-      "version": "3.1.25",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
-      "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-7.1.1.tgz",
+      "integrity": "sha512-rlqa8Lgh8YzT3Akruk05DR79j5gN9NCglHtJZwpi6vxVeaoagz+84UAtKQj/sT+RsfGaZkt3cdFCjcN6yjr5sw==",
       "license": "MIT",
       "dependencies": {
-        "conventional-changelog-angular": "^5.0.12",
-        "conventional-changelog-atom": "^2.0.8",
-        "conventional-changelog-codemirror": "^2.0.8",
-        "conventional-changelog-conventionalcommits": "^4.5.0",
-        "conventional-changelog-core": "^4.2.1",
-        "conventional-changelog-ember": "^2.0.9",
-        "conventional-changelog-eslint": "^3.0.9",
-        "conventional-changelog-express": "^2.0.6",
-        "conventional-changelog-jquery": "^3.0.11",
-        "conventional-changelog-jshint": "^2.0.9",
-        "conventional-changelog-preset-loader": "^2.3.4"
+        "@conventional-changelog/git-client": "^2.5.1",
+        "@types/normalize-package-data": "^2.4.4",
+        "conventional-changelog-preset-loader": "^5.0.0",
+        "conventional-changelog-writer": "^8.2.0",
+        "conventional-commits-parser": "^6.2.0",
+        "fd-package-json": "^2.0.0",
+        "meow": "^13.0.0",
+        "normalize-package-data": "^7.0.0"
+      },
+      "bin": {
+        "conventional-changelog": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-angular": {
@@ -4489,761 +4517,149 @@
         "node": ">=16"
       }
     },
-    "node_modules/conventional-changelog-atom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
-      "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
-      "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-codemirror": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
-      "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
-      "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-config-spec": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-config-spec/-/conventional-changelog-config-spec-2.1.0.tgz",
-      "integrity": "sha512-IpVePh16EbbB02V+UA+HQnnPIohgXvJRxHcS5+Uwk4AT5LjzCZJm5sp/yqs5C6KZJ1jMsV4paEV13BN1pvDuxQ==",
-      "license": "MIT"
-    },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
+      "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/conventional-changelog-core": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
-      "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
-      "license": "MIT",
-      "dependencies": {
-        "add-stream": "^1.0.0",
-        "conventional-changelog-writer": "^5.0.0",
-        "conventional-commits-parser": "^3.2.0",
-        "dateformat": "^3.0.0",
-        "get-pkg-repo": "^4.0.0",
-        "git-raw-commits": "^2.0.8",
-        "git-remote-origin-url": "^2.0.0",
-        "git-semver-tags": "^4.1.1",
-        "lodash": "^4.17.15",
-        "normalize-package-data": "^3.0.0",
-        "q": "^1.5.1",
-        "read-pkg": "^3.0.0",
-        "read-pkg-up": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/conventional-commits-parser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-text-path": "^1.0.1",
-        "JSONStream": "^1.0.4",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/git-raw-commits": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
-      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
-      "license": "MIT",
-      "dependencies": {
-        "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "git-raw-commits": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/is-text-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
-      "license": "MIT",
-      "dependencies": {
-        "text-extensions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/meow/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "license": "ISC",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/text-extensions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-core/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/conventional-changelog-core/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-ember": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
-      "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
-      "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-eslint": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
-      "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
-      "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-express": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
-      "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
-      "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-jquery": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
-      "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
-      "license": "ISC",
-      "dependencies": {
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-jshint": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
-      "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-preset-loader": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
-      "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
+      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
+      "integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
       "license": "MIT",
       "dependencies": {
-        "conventional-commits-filter": "^2.0.7",
-        "dateformat": "^3.0.0",
+        "conventional-commits-filter": "^5.0.0",
         "handlebars": "^4.7.7",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "semver": "^6.0.0",
-        "split": "^1.0.0",
-        "through2": "^4.0.0"
+        "meow": "^13.0.0",
+        "semver": "^7.5.2"
       },
       "bin": {
-        "conventional-changelog-writer": "cli.js"
+        "conventional-changelog-writer": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/meow": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "license": "MIT",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "license": "BSD-2-Clause",
+    "node_modules/conventional-changelog/node_modules/@conventional-changelog/git-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-2.5.1.tgz",
+      "integrity": "sha512-lAw7iA5oTPWOLjiweb7DlGEMDEvzqzLLa6aWOly2FSZ64IwLE8T458rC+o+WvI31Doz6joM7X2DoNog7mX8r4A==",
+      "license": "MIT",
       "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
+        "@simple-libs/child-process-utils": "^1.0.0",
+        "@simple-libs/stream-utils": "^1.1.0",
+        "semver": "^7.5.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "conventional-commits-filter": "^5.0.0",
+        "conventional-commits-parser": "^6.1.0"
+      },
+      "peerDependenciesMeta": {
+        "conventional-commits-filter": {
+          "optional": true
+        },
+        "conventional-commits-parser": {
+          "optional": true
+        }
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
+    "node_modules/conventional-changelog/node_modules/conventional-commits-parser": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.0.tgz",
+      "integrity": "sha512-uLnoLeIW4XaoFtH37qEcg/SXMJmKF4vi7V0H2rnPueg+VEtFGA/asSCNTcq4M/GQ6QmlzchAEtOoDTtKqWeHag==",
+      "license": "MIT",
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
       "bin": {
-        "semver": "bin/semver.js"
+        "conventional-commits-parser": "dist/cli/index.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
+    "node_modules/conventional-changelog/node_modules/hosted-git-info": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+      "license": "ISC",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/conventional-changelog/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/conventional-changelog/node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg-up": {
+    "node_modules/conventional-changelog/node_modules/normalize-package-data": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-changelog-writer/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/conventional-changelog-writer/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog/node_modules/conventional-changelog-angular": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "hosted-git-info": "^8.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-changelog/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
-      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/conventional-commits-filter": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
       "license": "MIT",
-      "dependencies": {
-        "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -5264,346 +4680,11 @@
         "node": ">=16"
       }
     },
-    "node_modules/conventional-recommended-bump": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
-      "integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
-      "license": "MIT",
-      "dependencies": {
-        "concat-stream": "^2.0.0",
-        "conventional-changelog-preset-loader": "^2.3.4",
-        "conventional-commits-filter": "^2.0.7",
-        "conventional-commits-parser": "^3.2.0",
-        "git-raw-commits": "^2.0.8",
-        "git-semver-tags": "^4.1.1",
-        "meow": "^8.0.0",
-        "q": "^1.5.1"
-      },
-      "bin": {
-        "conventional-recommended-bump": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-text-path": "^1.0.1",
-        "JSONStream": "^1.0.4",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/git-raw-commits": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
-      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
-      "license": "MIT",
-      "dependencies": {
-        "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "git-raw-commits": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/is-text-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-      "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
-      "license": "MIT",
-      "dependencies": {
-        "text-extensions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/meow": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "license": "ISC",
-      "dependencies": {
-        "readable-stream": "^3.0.0"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/text-extensions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-      "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/conventional-recommended-bump/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -5732,15 +4813,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -5756,40 +4828,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "license": "MIT",
-      "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/decode-named-character-reference": {
@@ -5879,19 +4917,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/detect-indent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5932,102 +4962,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotgitignore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",
-      "integrity": "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==",
-      "license": "ISC",
-      "dependencies": {
-        "find-up": "^3.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/dotgitignore/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -7379,28 +6313,22 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
       "license": "MIT",
       "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "walk-up-path": "^4.0.0"
       }
     },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
+    "node_modules/fd-package-json/node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "license": "ISC",
       "engines": {
-        "node": ">=0.8.0"
+        "node": "20 || >=22"
       }
     },
     "node_modules/file-entry-cache": {
@@ -7627,217 +6555,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-pkg-repo": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
-      "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@hutson/parse-repository-url": "^3.0.0",
-        "hosted-git-info": "^4.0.0",
-        "through2": "^2.0.0",
-        "yargs": "^16.2.0"
-      },
-      "bin": {
-        "get-pkg-repo": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/get-pkg-repo/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/get-pkg-repo/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
-    "node_modules/get-pkg-repo/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/get-pkg-repo/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/get-pkg-repo/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/get-pkg-repo/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -7910,309 +6627,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/git-remote-origin-url": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-remote-origin-url/-/git-remote-origin-url-2.0.0.tgz",
-      "integrity": "sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw==",
-      "license": "MIT",
-      "dependencies": {
-        "gitconfiglocal": "^1.0.0",
-        "pify": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/git-remote-origin-url/node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/git-semver-tags": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
-      "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
-      "license": "MIT",
-      "dependencies": {
-        "meow": "^8.0.0",
-        "semver": "^6.0.0"
-      },
-      "bin": {
-        "git-semver-tags": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/meow": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
-      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
-    "node_modules/git-semver-tags/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gitconfiglocal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
-      "integrity": "sha512-spLUXeTAVHxDtKsJc8FkFVgFtMdEN9qPGpL23VfSHx4fP4+Ds097IXLvymbnDH8FnmxX5Nr9bPw3A+AQ6mWEaQ==",
-      "license": "BSD",
-      "dependencies": {
-        "ini": "^1.3.2"
-      }
-    },
-    "node_modules/gitconfiglocal/node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -8372,15 +6786,6 @@
       },
       "optionalDependencies": {
         "uglify-js": "^3.1.4"
-      }
-    },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/has-bigints": {
@@ -8578,15 +6983,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -10811,12 +9207,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT"
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10884,15 +9274,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -11075,22 +9456,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.ismatch": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -11309,18 +9678,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
-      }
-    },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/markdown-extensions": {
@@ -12414,15 +10771,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -12447,29 +10795,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "license": "MIT",
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/minimist-options/node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -12477,15 +10802,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/modify-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
-      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ms": {
@@ -13107,6 +11423,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13466,12 +11783,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -13546,17 +11857,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13576,15 +11876,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/quotation": {
       "version": "2.0.3",
@@ -13640,86 +11931,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha512-YFzFrVvpC6frF1sz8psoHDBGF7fLPc+llq/8NB43oagqWkx8ar5zYtsTORtOjw9W2RHLpWP+zTWwBvf1bCmcSw==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/read-pkg/node_modules/path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -13756,19 +11967,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/refa": {
@@ -15372,18 +13570,6 @@
       "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
       "license": "CC0-1.0"
     },
-    "node_modules/split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "license": "MIT",
-      "dependencies": {
-        "through": "2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -15421,264 +13607,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/standard-version": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-9.5.0.tgz",
-      "integrity": "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "conventional-changelog": "3.1.25",
-        "conventional-changelog-config-spec": "2.1.0",
-        "conventional-changelog-conventionalcommits": "4.6.3",
-        "conventional-recommended-bump": "6.1.0",
-        "detect-indent": "^6.0.0",
-        "detect-newline": "^3.1.0",
-        "dotgitignore": "^2.1.0",
-        "figures": "^3.1.0",
-        "find-up": "^5.0.0",
-        "git-semver-tags": "^4.0.0",
-        "semver": "^7.1.1",
-        "stringify-package": "^1.0.1",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "standard-version": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/standard-version/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/standard-version/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/standard-version/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/standard-version/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
-    "node_modules/standard-version/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
-      "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/standard-version/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/standard-version/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/standard-version/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/standard-version/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/standard-version/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/standard-version/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/standard-version/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/standard-version/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/standard-version/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/standard-version/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/standard-version/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/standard-version/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/standard-version/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/standard-version/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -15949,13 +13877,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/stringify-package": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz",
-      "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
-      "deprecated": "This module is not used anymore, and has been replaced by @npmcli/package-json",
-      "license": "ISC"
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -15999,18 +13920,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -16142,15 +14051,6 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
     "node_modules/tinyexec": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
@@ -16185,15 +14085,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/trough": {
@@ -16427,9 +14318,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.0.tgz",
-      "integrity": "sha512-wNKHUY2hYYkf6oSFfhwwiHo4WCHzHmzcXsqXYTN9ja3iApYIFbb2U6ics9hBcYLHcYGQoAlwnZlTrf3oF+BL/Q==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -17346,15 +15237,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     ".github/workflows/release.yml",
     ".github/workflows/test.yml",
     ".husky/commit-msg",
-    ".husky/post-commit",
     ".husky/pre-commit"
   ],
   "engines": {
@@ -38,13 +37,14 @@
   "dependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
+    "conventional-changelog": "^7.1.1",
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "eslint": "^8.57.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.6.2",
     "remark-cli": "^12.0.1",
-    "standard-version": "^9.5.0",
     "yargs": "^18.0.0"
   },
   "devDependencies": {
@@ -77,21 +77,14 @@
     "lint:styles:fix": "npm run prettier -- --write",
     "format": "npm-run-all --print-label --silent --parallel lint:*:fix",
     "clean": "git clean -dx --force --exclude=node_modules --exclude=.husky",
-    "prerelease": "git switch main && git pull && npm ci && npm run clean && npm test && npm run clean",
-    "release": "standard-version",
-    "release:dry-run": "standard-version --dry-run",
+    "changelog": "conventional-changelog --preset conventionalcommits --release-count 0 && prettier --write CHANGELOG.md",
+    "postversion": "npm run changelog",
     "prepare": "husky"
   },
   "lint-staged": {
     "*.{js,jsx,cjs,mjs,ts,tsx}": "eslint --cache --fix",
     "!(**/*.snap|.husky/**)": "prettier --cache --write",
     "!(CHANGELOG).md": "remark --frail"
-  },
-  "standard-version": {
-    "sign": true,
-    "scripts": {
-      "postchangelog": "prettier --write CHANGELOG.md"
-    }
   },
   "remarkConfig": {
     "plugins": [
@@ -120,6 +113,7 @@
           "",
           "actions",
           "api",
+          "changelog",
           "commitlint",
           "coverage",
           "deps",
@@ -134,7 +128,6 @@
           "readme",
           "release",
           "remark",
-          "standard-version",
           "types"
         ]
       ]

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -42,6 +42,7 @@ exports[`update "package.json" 1`] = `
     ],
   },
   "scripts": {
+    "changelog": "conventional-changelog --preset conventionalcommits --release-count 0 && prettier --write CHANGELOG.md",
     "clean": "git clean -dx --force --exclude=node_modules --exclude=.husky",
     "format": "npm-run-all --print-label --silent --parallel lint:*:fix",
     "lint": "npm-run-all --print-label --silent --parallel lint:*",
@@ -54,21 +55,13 @@ exports[`update "package.json" 1`] = `
     "lint:styles:fix": "npm run prettier -- --write",
     "lint:types": "tsc --noEmit",
     "lint:types:watch": "npm run lint:types -- --watch",
+    "postversion": "npm run changelog",
     "prepare": "husky",
-    "prerelease": "git switch main && git pull && npm ci && npm run clean && npm test && npm run clean",
     "pretest": "npm run lint",
     "prettier": "prettier --cache .",
-    "release": "standard-version",
-    "release:dry-run": "standard-version --dry-run",
     "test": "abc",
     "test:coverage": "npm --ignore-scripts test -- --coverage",
     "test:watch": "npm --ignore-scripts test -- --watch",
-  },
-  "standard-version": {
-    "scripts": {
-      "postchangelog": "prettier --write CHANGELOG.md",
-    },
-    "sign": true,
   },
 }
 `;
@@ -113,6 +106,7 @@ exports[`update "package.json" without fields 1`] = `
     ],
   },
   "scripts": {
+    "changelog": "conventional-changelog --preset conventionalcommits --release-count 0 && prettier --write CHANGELOG.md",
     "clean": "git clean -dx --force --exclude=node_modules --exclude=.husky",
     "format": "npm-run-all --print-label --silent --parallel lint:*:fix",
     "lint": "npm-run-all --print-label --silent --parallel lint:*",
@@ -125,21 +119,13 @@ exports[`update "package.json" without fields 1`] = `
     "lint:styles:fix": "npm run prettier -- --write",
     "lint:types": "tsc --noEmit",
     "lint:types:watch": "npm run lint:types -- --watch",
+    "postversion": "npm run changelog",
     "prepare": "husky",
-    "prerelease": "git switch main && git pull && npm ci && npm run clean && npm test && npm run clean",
     "pretest": "npm run lint",
     "prettier": "prettier --cache .",
-    "release": "standard-version",
-    "release:dry-run": "standard-version --dry-run",
     "test": "test",
     "test:coverage": "npm --ignore-scripts test -- --coverage",
     "test:watch": "npm --ignore-scripts test -- --watch",
-  },
-  "standard-version": {
-    "scripts": {
-      "postchangelog": "prettier --write CHANGELOG.md",
-    },
-    "sign": true,
   },
 }
 `;
@@ -270,11 +256,6 @@ jobs:
 
 exports[`write ".husky/commit-msg" 1`] = `
 "commitlint --edit "$1"
-"
-`;
-
-exports[`write ".husky/post-commit" 1`] = `
-"npm run release:dry-run
 "
 `;
 

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -59,7 +59,6 @@ test('update "package.json" without fields', () =>
   ".github/workflows/release.yml",
   ".github/workflows/test.yml",
   ".husky/commit-msg",
-  ".husky/post-commit",
   ".husky/pre-commit",
 ].forEach((file) => {
   test(`write "${file}"`, () =>
@@ -96,10 +95,10 @@ test("End-to-End via CLI", () =>
       => [32m'.github/workflows/release.yml'[39m was updated
       => [32m'.github/workflows/test.yml'[39m was updated
       => [32m'.husky/commit-msg'[39m was updated
-      => [32m'.husky/post-commit'[39m was updated
       => [32m'.husky/pre-commit'[39m was updated
       => [32m'.husky/.gitignore'[39m was removed
       => [32m'.github/workflows/commitlint.yml'[39m was removed
+      => [32m'.husky/post-commit'[39m was removed
       "
     `);
     expect(stderr).toEqual("");


### PR DESCRIPTION
BREAKING CHANGE: `CHANGELOG.md` is reformatted, and `.husky/post-commit` is removed.

Close #1282