### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,9 +1216,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6811,9 +6811,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
This pull request fixes the vulnerable packages via [npm v11.18.0](https://github.com/npm/cli/releases/tag/v11.18.0).

<details open>
<summary><strong>Updated (2)</strong></summary>

| Package | Version | Source | Severity | Link |
|:--------|:-------:|:------:|:--------:|:-----|
| [js-yaml](https://www.npmjs.com/package/js-yaml/v/3.15.0)<br>(`@istanbuljs/load-nyc-config/node_modules/js-yaml`) | `3.14.2`→`3.15.0` | [github](https://github.com/nodeca/js-yaml) | **Moderate** | <https://github.com/advisories/GHSA-h67p-54hq-rp68> |
| [js-yaml](https://www.npmjs.com/package/js-yaml/v/4.3.0) | `4.1.1`→`4.3.0` | [github](https://github.com/nodeca/js-yaml) | **Moderate** | <https://github.com/advisories/GHSA-h67p-54hq-rp68> |

</details>

This pull request was created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action) in the [action run](https://github.com/ybiquitous/ybiq/actions/runs/28988344027).