### PR TITLE
chore: update `engines.node` for 22.17.0 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript-eslint": "^8.62.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=22.17.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     ".github/workflows/test.yml"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.17.0"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
Follows up to #2119
Blocks #2117