### PR TITLE
feat(init)!: remove `conventional-changelog-conventionalcommits` overrides and bump it from 9.1.0 to 10.2.1

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -121,16 +121,14 @@ const initCommand = (baseDir, logger) => {
       // standard-version is no longer used.
       delete packageInfo["standard-version"];
 
-      // NOTE: This adds `overrides` to forcibly use the latest version of `conventional-changelog-conventionalcommits`
-      // because `@commitlint/config-conventional` depends on the old version.
-      // TODO: Remove this "overrides" after the following PR is resolved:
-      // https://github.com/conventional-changelog/commitlint/pull/4417
-      const convCommitsPkg = "conventional-changelog-conventionalcommits";
-      if (!packageInfo.overrides) {
-        packageInfo.overrides = {};
+      // The `overrides` for `conventional-changelog-conventionalcommits` is no longer needed.
+      // Remove it if a previous `init` added it.
+      if (packageInfo.overrides) {
+        delete packageInfo.overrides["conventional-changelog-conventionalcommits"];
+        if (Object.keys(packageInfo.overrides).length === 0) {
+          delete packageInfo.overrides;
+        }
       }
-      packageInfo.overrides[convCommitsPkg] = originalPackage.overrides[convCommitsPkg];
-      logger(`=> ${emphasize(convCommitsPkg)} is overridden. Run \`npm i\`.`);
 
       await write("package.json", JSON.stringify(packageInfo, null, 2));
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@commitlint/config-conventional": "^21.1.0",
         "@eslint/js": "^10.0.1",
         "conventional-changelog": "^7.2.1",
-        "conventional-changelog-conventionalcommits": "^9.1.0",
+        "conventional-changelog-conventionalcommits": "^10.2.1",
         "eslint": "^10.6.0",
         "lint-staged": "^17.0.8",
         "prettier": "^3.9.4",
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@conventional-changelog/template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.0.tgz",
-      "integrity": "sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
       "license": "MIT",
       "engines": {
         "node": ">=22"
@@ -3298,12 +3298,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/array-ify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
-      "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
-      "license": "MIT"
-    },
     "node_modules/babel-jest": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
@@ -3946,16 +3940,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/compare-func": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-      "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-      "license": "MIT",
-      "dependencies": {
-        "array-ify": "^1.0.0",
-        "dot-prop": "^5.1.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4014,15 +3998,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
-      "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
       "license": "ISC",
       "dependencies": {
-        "compare-func": "^2.0.0"
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/conventional-changelog-preset-loader": {
@@ -4233,18 +4217,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/dot-prop": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "is-obj": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/eastasianwidth": {
@@ -5470,15 +5442,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {

--- a/package.json
+++ b/package.json
@@ -40,15 +40,12 @@
     "@commitlint/config-conventional": "^21.1.0",
     "@eslint/js": "^10.0.1",
     "conventional-changelog": "^7.2.1",
-    "conventional-changelog-conventionalcommits": "^9.1.0",
+    "conventional-changelog-conventionalcommits": "^10.2.1",
     "eslint": "^10.6.0",
     "lint-staged": "^17.0.8",
     "prettier": "^3.9.4",
     "remark-cli": "^12.0.1",
     "yargs": "^18.0.0"
-  },
-  "overrides": {
-    "conventional-changelog-conventionalcommits": "^9.1.0"
   },
   "devDependencies": {
     "@tsconfig/strictest": "^2.0.8",

--- a/test/__snapshots__/init.test.js.snap
+++ b/test/__snapshots__/init.test.js.snap
@@ -20,9 +20,6 @@ exports[`update "package.json" 1`] = `
     "*.css": "xyz",
     "*.{js,jsx,cjs,mjs,ts,tsx}": "eslint --cache --fix",
   },
-  "overrides": {
-    "conventional-changelog-conventionalcommits": "^9.1.0",
-  },
   "publishConfig": {
     "access": true,
     "provenance": true,
@@ -76,9 +73,6 @@ exports[`update "package.json" without fields 1`] = `
     "!(**/*.snap|.githooks/**)": "prettier --cache --write",
     "!(CHANGELOG).md": "remark --frail",
     "*.{js,jsx,cjs,mjs,ts,tsx}": "eslint --cache --fix",
-  },
-  "overrides": {
-    "conventional-changelog-conventionalcommits": "^9.1.0",
   },
   "publishConfig": {
     "provenance": true,

--- a/test/fixtures/package-overrides.json
+++ b/test/fixtures/package-overrides.json
@@ -1,5 +1,6 @@
 {
   "overrides": {
+    "conventional-changelog-conventionalcommits": "^9.1.0",
     "foo": "1.2.3"
   }
 }

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -50,6 +50,24 @@ test('update "package.json" without fields', () =>
     expect(readJSON(src)).toMatchSnapshot();
   }));
 
+test("remove `overrides` for `conventional-changelog-conventionalcommits`", () =>
+  sandbox(async (ctx) => {
+    const src = ctx.fixture("package-overrides.json");
+    await init(ctx.initArgs);
+    expect(readJSON(src).overrides).toEqual({ foo: "1.2.3" });
+  }));
+
+test("remove empty `overrides` after dropping `conventional-changelog-conventionalcommits`", () =>
+  sandbox(async (ctx) => {
+    const src = ctx.fixture("package-normal.json");
+    writeFileSync(
+      src,
+      JSON.stringify({ overrides: { "conventional-changelog-conventionalcommits": "^9.1.0" } }),
+    );
+    await init(ctx.initArgs);
+    expect(readJSON(src)).not.toHaveProperty("overrides");
+  }));
+
 [
   [".editorconfig", true],
   [".remarkignore", true],
@@ -89,8 +107,7 @@ test("End-to-End via CLI", () =>
       cwd: ctx.initArgs.cwd,
     });
     expect(stdout).toMatchInlineSnapshot(`
-      "=> [32m'conventional-changelog-conventionalcommits'[39m is overridden. Run \`npm i\`.
-      => [32m'package.json'[39m was updated
+      "=> [32m'package.json'[39m was updated
       => [32m'.editorconfig'[39m was updated
       => [32m'.remarkignore'[39m was updated
       => [32m'eslint.config.js'[39m was updated
@@ -129,24 +146,4 @@ test("remove `.github/workflows/commitlint.yml` if exists", () =>
     await init(ctx.initArgs);
 
     expect(existsSync(join(ctx.workDir, ".github", "workflows", "commitlint.yml"))).toEqual(false);
-  }));
-
-test("overrids `conventional-changelog-conventionalcommits` with the consistent version", () =>
-  sandbox(async (ctx) => {
-    const src = ctx.fixture("package-normal.json");
-    await init(ctx.initArgs);
-    expect(readJSON(src).overrides["conventional-changelog-conventionalcommits"]).toEqual(
-      pkg.dependencies["conventional-changelog-conventionalcommits"],
-    );
-  }));
-
-test("overrids `conventional-changelog-conventionalcommits` keeping other packages", () =>
-  sandbox(async (ctx) => {
-    const src = ctx.fixture("package-overrides.json");
-    await init(ctx.initArgs);
-    expect(readJSON(src).overrides).toEqual({
-      "conventional-changelog-conventionalcommits":
-        pkg.dependencies["conventional-changelog-conventionalcommits"],
-      foo: "1.2.3",
-    });
   }));


### PR DESCRIPTION
BREAKING CHANGE: `init` no longer adds the `overrides` field to `package.json` and removes the previously injected `conventional-changelog-conventionalcommits` override.

The `overrides` hack that forced the latest `conventional-changelog-conventionalcommits` is no longer needed, since `@commitlint/config-conventional` no longer pins the old version.

See also #1998

---

```sh-session
ybiq@21.0.3 /Users/masafumi/git/ybiquitous/ybiq
├─┬ @commitlint/config-conventional@21.2.0
│ └── conventional-changelog-conventionalcommits@10.2.1 deduped
└── conventional-changelog-conventionalcommits@10.2.1
```