### PR TITLE
feat: simplify type definitions

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -1,9 +1,9 @@
+import { EOL } from "node:os";
 import { promises as fsPromises } from "node:fs";
 import { join, relative, resolve } from "node:path";
 import { inspect } from "node:util";
-import { defaultLogger } from "./logger.js";
 
-/** @import { Logger, InitCommand } from "../types/ybiq.d.ts" */
+/** @import { init as initFunc } from "../types/ybiq.d.ts" */
 
 const { copyFile, mkdir, readFile, writeFile, rm } = fsPromises;
 
@@ -20,9 +20,14 @@ const PACKAGE_DIR = new URL("..", import.meta.url).pathname;
  */
 const packagePath = (elem, ...elems) => join(PACKAGE_DIR, elem, ...elems);
 
+/** @type {(message: string) => void} */
+const defaultLogger = (message) => {
+  process.stdout.write(`${message}${EOL}`);
+};
+
 /**
  * @param {string} baseDir
- * @param {Logger} logger
+ * @param {typeof defaultLogger} logger
  */
 const initCommand = (baseDir, logger) => {
   /**
@@ -159,7 +164,7 @@ const initCommand = (baseDir, logger) => {
   };
 };
 
-/** @type {InitCommand} */
+/** @type {typeof initFunc} */
 export async function init({ cwd = process.cwd(), logger = defaultLogger } = {}) {
   const cmd = initCommand(cwd, logger);
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,8 +1,0 @@
-import { EOL } from "node:os";
-
-/** @import { Logger } from "../types/ybiq.d.ts"; */
-
-/** @type {Logger} */
-export const defaultLogger = (msg) => {
-  process.stdout.write(`${msg}${EOL}`);
-};

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,7 +3,7 @@ import { once } from "node:events";
 import * as readline from "node:readline/promises"; // eslint-disable-line n/no-unsupported-features/node-builtins
 import { styleText } from "node:util"; // eslint-disable-line n/no-unsupported-features/node-builtins
 
-/** @import { RunCommand, RunResult, RunLabeler } from "../types/ybiq.d.ts"; */
+/** @import { run as runFunc } from "../types/ybiq.d.ts"; */
 
 /** @typedef {"blue" | "cyan" | "green" | "magenta" | "red" | "yellow"} Color */
 /** @typedef {Parameters<typeof styleText>[0]} Styles */
@@ -11,7 +11,7 @@ import { styleText } from "node:util"; // eslint-disable-line n/no-unsupported-f
 /** @type {readonly Color[]} */
 const COLORS = Object.freeze(["blue", "cyan", "green", "magenta", "red", "yellow"]);
 
-/** @type {RunLabeler} */
+/** @type {(script: string) => string} */
 const defaultLabeler = (script) => script;
 
 /**
@@ -37,11 +37,11 @@ function output({ label, color, line, dest }) {
  * @param {{
  *   script: string;
  *   color: Color;
- *   labeler: RunLabeler;
+ *   labeler: typeof defaultLabeler;
  *   stdout: NodeJS.WriteStream;
  *   stderr: NodeJS.WriteStream;
  * }} params
- * @returns {Promise<RunResult>}
+ * @returns {Promise<{ script: string; success: boolean; code: number | undefined; error: Error | undefined }>}
  */
 async function runScript({ script, color, labeler, stdout, stderr }) {
   const childProcess = spawn(script, { shell: true, stdio: "pipe" });
@@ -67,7 +67,7 @@ async function runScript({ script, color, labeler, stdout, stderr }) {
     : { script, success: false, code: code || undefined, error: undefined };
 }
 
-/** @type {RunCommand} */
+/** @type {typeof runFunc} */
 export async function run({
   scripts,
   npm = false,

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -1,9 +1,0 @@
-import { jest } from "@jest/globals"; // eslint-disable-line n/no-extraneous-import
-import { defaultLogger } from "../lib/logger.js";
-
-test("defaultLogger", () => {
-  const spy = jest.spyOn(process.stdout, "write");
-  defaultLogger("test message");
-  expect(spy).toHaveBeenCalled();
-  spy.mockRestore();
-});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ESNext"],
     "noEmit": true,
     "checkJs": true,
+    "skipLibCheck": false,
     "types": ["node"]
   },
   "include": ["lib/**/*", "types/**/*"]

--- a/types/ybiq.d.ts
+++ b/types/ybiq.d.ts
@@ -1,31 +1,20 @@
-export type Logger = (msg: string) => void;
-export type CommandParams = {
-  readonly cwd?: string | undefined;
-  readonly logger?: Logger | undefined;
-};
+export declare function init(params?: {
+  cwd?: string | undefined;
+  logger?: ((msg: string) => void) | undefined;
+}): Promise<void>;
 
-export declare function init(params?: CommandParams): Promise<void>;
-type InitCommand = typeof init;
-
-export type RunLabeler = (script: string) => string;
-
-export type RunParams = {
-  readonly scripts: ReadonlyArray<string>;
-  readonly npm?: boolean | undefined;
-  readonly labeler?: RunLabeler | undefined;
-  readonly stdout?: NodeJS.WriteStream | undefined;
-  readonly stderr?: NodeJS.WriteStream | undefined;
-};
-
-export type RunResult = {
-  readonly script: string;
-  readonly success: boolean;
-  readonly code: number | undefined;
-  readonly error: Error | undefined;
-};
-
-export declare function run(params: Readonly<RunParams>): Promise<{
+export declare function run(params: {
+  scripts: Array<string>;
+  npm?: boolean | undefined;
+  labeler?: ((script: string) => string) | undefined;
+  stdout?: NodeJS.WriteStream | undefined;
+  stderr?: NodeJS.WriteStream | undefined;
+}): Promise<{
   success: boolean;
-  results: Array<RunResult>;
+  results: Array<{
+    script: string;
+    success: boolean;
+    code: number | undefined;
+    error: Error | undefined;
+  }>;
 }>;
-type RunCommand = typeof run;


### PR DESCRIPTION
- Inline types that are not directly used by users.
- Refactor to inline a tiny module `lib/logger.js`.
- Disable `skipLibCheck` for `tsc` to detect undefined type definitions.