### PR TITLE
feat(run): add `cwd` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ await run({
   // labeler: (script) => script,  // Customize script labels
   // stdout: process.stdout,
   // stderr: process.stderr,
+  // cwd: process.cwd(),
 });
 ```
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -40,15 +40,14 @@ function output({ label, color, line, dest }) {
  *   labeler: typeof defaultLabeler;
  *   stdout: NodeJS.WriteStream;
  *   stderr: NodeJS.WriteStream;
+ *   cwd: string | undefined;
  * }} params
  * @returns {Promise<{ script: string; success: boolean; code: number | undefined; error: Error | undefined }>}
  */
-async function runScript({ script, color, labeler, stdout, stderr }) {
-  const childProcess = spawn(script, { shell: true, stdio: "pipe" });
+async function runScript({ script, color, labeler, stdout, stderr, cwd }) {
+  const childProcess = spawn(script, { shell: true, stdio: "pipe", cwd });
   const label = labeler(script);
 
-  // `readline` splits each stream into complete lines, so output does not
-  // depend on nondeterministic chunk boundaries.
   /** @type {(input: NodeJS.ReadableStream, dest: NodeJS.WriteStream) => Promise<void>} */
   const pipe = async (input, dest) => {
     for await (const line of readline.createInterface({ input, crlfDelay: Infinity })) {
@@ -56,15 +55,27 @@ async function runScript({ script, color, labeler, stdout, stderr }) {
     }
   };
 
-  const [[code]] = await Promise.all([
-    once(childProcess, "close"),
-    pipe(childProcess.stdout, stdout),
-    pipe(childProcess.stderr, stderr),
-  ]);
+  try {
+    const [[code]] = await Promise.all([
+      once(childProcess, "close"),
+      pipe(childProcess.stdout, stdout),
+      pipe(childProcess.stderr, stderr),
+    ]);
 
-  return code === 0
-    ? { script, success: true, code, error: undefined }
-    : { script, success: false, code: code || undefined, error: undefined };
+    return {
+      script,
+      success: code === 0,
+      code: code ?? undefined,
+      error: undefined,
+    };
+  } catch (error) {
+    return {
+      script,
+      success: false,
+      code: undefined,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
 }
 
 /** @type {typeof runFunc} */
@@ -74,6 +85,7 @@ export async function run({
   labeler = defaultLabeler,
   stdout = process.stdout,
   stderr = process.stderr,
+  cwd = undefined,
 }) {
   // Rotate colors for each script label
   const results = await Promise.allSettled(
@@ -81,7 +93,7 @@ export async function run({
       const script = npm ? `npm run ${originalScript}` : originalScript;
       /** @type {Color} */
       const color = COLORS[index % COLORS.length] ?? "cyan";
-      return runScript({ script, color, labeler, stdout, stderr });
+      return runScript({ script, color, labeler, stdout, stderr, cwd });
     }),
   );
 

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -96,6 +96,23 @@ test("finish with errors when some scripts fail", async () => {
   );
 });
 
+test("return a structured error when a script cannot be spawned", async () => {
+  const script = 'echo "Hi"';
+  const result = await runWithMocks([script], { cwd: "/no/such/ybiq/dir" });
+
+  expect(result.success).toBe(false);
+  expect(result.results).toHaveLength(1);
+  expect(result.results[0]).toMatchObject({
+    script: script,
+    success: false,
+    code: undefined,
+    error: expect.any(Error),
+  });
+  expect(result.results[0].error.message).toMatch(/ENOENT/u);
+  expect(stdoutMock.write).not.toHaveBeenCalled();
+  expect(stderrMock.write).not.toHaveBeenCalled();
+});
+
 test("run npm scripts", async () => {
   const scripts = ["postprepare"];
   const result = await runWithMocks(scripts, { npm: true });

--- a/types/ybiq.d.ts
+++ b/types/ybiq.d.ts
@@ -9,6 +9,7 @@ export declare function run(params: {
   labeler?: ((script: string) => string) | undefined;
   stdout?: NodeJS.WriteStream | undefined;
   stderr?: NodeJS.WriteStream | undefined;
+  cwd?: string | undefined;
 }): Promise<{
   success: boolean;
   results: Array<{


### PR DESCRIPTION
Adds a new `cwd` option to `run()`. Defaults to `undefined`, which means `process.cwd()`.

Also handles an error caused by `spawn()`, although it rarely happens.