### PR TITLE
chore(commitlint): relax `footer-max-line-length` and `header-max-length`

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
       "footer-max-line-length": [
         2,
         "always",
-        120
+        200
       ],
       "header-max-length": [
         2,
         "always",
-        120
+        200
       ],
       "scope-enum": [
         2,


### PR DESCRIPTION
Fixes the lint error:

```sh-session
$ npm run lint:commit
npm notice run ybiq@21.0.3 lint:commit
npm notice run commitlint --from HEAD~10
⧗   --- input ---
feat(changelog)!: add `ybiq changelog` command and drop `.remarkignore` (#2129)

BREAKING CHANGE: `ybiq init` no longer writes `.remarkignore` and removes an existing one when it solely ignores `CHANGELOG.md`. `npm run changelog` now calls `ybiq changelog`.
✖   footer's lines must not be longer than 120 characters [footer-max-line-length]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint
```