### PR TITLE
chore(lint): add CWE-tagged security rules for lib

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from "eslint/config";
 
 import nodePlugin from "eslint-plugin-n";
 import tsPlugin from "typescript-eslint";
+import secureCoding from 'eslint-plugin-secure-coding';
 
 export default defineConfig([
   // Base
@@ -38,5 +39,16 @@ export default defineConfig([
     rules: {
       "n/no-extraneous-import": "off",
     },
+  },
+
+  // Security rules, CWE- and CVSS-tagged, scoped to source.
+  //
+  // Measured against this repository before proposing it: 0 findings across
+  // lib/**/*.{js,mjs,cjs,ts,tsx}. That is the point rather than a caveat — the block goes red on a
+  // new one, not on what is here today.
+  {
+    files: ['lib/**/*.{js,mjs,cjs,ts,tsx}'],
+    plugins: { 'secure-coding': secureCoding },
+    rules: secureCoding.configs.recommended.rules,
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^26.1.0",
         "@types/yargs": "^17.0.35",
         "eslint-plugin-n": "^18.2.2",
+        "eslint-plugin-secure-coding": "4.3.0",
         "remark-preset-ybiquitous": "^0.5.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.65.0"
@@ -574,6 +575,37 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@interlace/eslint-devkit": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@interlace/eslint-devkit/-/eslint-devkit-1.17.2.tgz",
+      "integrity": "sha512-owpOOCCBUeJ+r93Fkb0TzfBOdgDbpptT7FJYR8bWA8PU//8SnTlHOXg7juQl4G9kEvFPoKAVRnNJSQOYryF6Ng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/ofri-peretz/eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0",
+        "oxc-resolver": "^11.24.2",
+        "typescript": ">=4.8.4"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "oxc-resolver": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2399,6 +2431,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/eslint-plugin-secure-coding": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-secure-coding/-/eslint-plugin-secure-coding-4.3.0.tgz",
+      "integrity": "sha512-xzDhBldR+jFj87oqIhpzdrxKqN2ZSKoO3YNVVauNX7Z56sSGNVT4VeAGsldFCO752zJI2Mt9UHZv2WsDXmfVQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@interlace/eslint-devkit": "^1.16.0",
+        "scslre": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "git+https://github.com/ofri-peretz/eslint.git"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -4745,6 +4799,33 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/remark": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
@@ -5816,6 +5897,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/node": "^26.1.0",
     "@types/yargs": "^17.0.35",
     "eslint-plugin-n": "^18.2.2",
+    "eslint-plugin-secure-coding": "4.3.0",
     "remark-preset-ybiquitous": "^0.5.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"


### PR DESCRIPTION
## What

Adds `eslint-plugin-secure-coding` and enables its recommended rules on `lib/**/*.{js,mjs,cjs,ts,tsx}`.

**No defect is claimed.** I measured this repository before proposing anything: **0 findings** across the scoped paths. That is the reason to add it rather than a caveat — the block can only go red on something introduced later.

## Why this repository

It already runs ESLint with a flat config and lints in CI, and there is no security plugin in the chain today. The rules carry CWE and CVSS metadata, so a finding arrives with a classification rather than a message to interpret.

## What I checked before opening this

- **Zero findings** on `lib/**/*.{js,mjs,cjs,ts,tsx}` with the recommended preset, using the version pinned below.
- **Pinned exactly**, not as a range, so you are approving the version this was measured against.
- **Your 7-day minimum release age** (declared in your dependency config) — the pin is `4.3.0`, which is older than that window. No exception requested.
- **Scoped to source**, not the whole repository: tests, fixtures and build output are excluded.
- Lockfile updated with a lockfile-only install; no install scripts were run.

## If this is not wanted

Close it and I will not open another. If you would rather have a subset — say, only the injection rules — tell me which and I will send that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
